### PR TITLE
Make support email address configurable in error page

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2339,7 +2339,7 @@ function createEnhancedErrorPage(error, requestId, validationResults = null) {
                 🚨 Emergency Reset
               </button>
               <br><br>
-              <a href="mailto:admin@domain.com?subject=Danielson Framework Error&body=Error ID: ${Utilities.encodeHtml(errorId)}%0ATimestamp: ${Utilities.encodeHtml(new Date(timestamp).toISOString())}%0AError: ${encodeURIComponent(error.toString())}"
+              <a href="mailto:${CONTACT_SETTINGS.SUPPORT_EMAIL}?subject=Danielson Framework Error&body=Error ID: ${Utilities.encodeHtml(errorId)}%0ATimestamp: ${Utilities.encodeHtml(new Date(timestamp).toISOString())}%0AError: ${encodeURIComponent(error.toString())}"
                  class="action-button" style="background: #6c757d;">
                 📧 Contact Support
               </a>

--- a/Constants.js
+++ b/Constants.js
@@ -195,6 +195,13 @@ const SYSTEM_INFO = {
 };
 
 /**
+ * Contact settings
+ */
+const CONTACT_SETTINGS = {
+  SUPPORT_EMAIL: 'admin@example.com'
+};
+
+/**
  * Auto-trigger system settings
  */
 const AUTO_TRIGGER_SETTINGS = {


### PR DESCRIPTION
The hardcoded email address in the mailto link within the `createEnhancedErrorPage` function in `Code.js` has been replaced with a configurable constant.

A new constant `SUPPORT_EMAIL` was added to `Constants.js` within a `CONTACT_SETTINGS` object. The `createEnhancedErrorPage` function now uses this constant to construct the support email link.

This change allows for easier maintenance and updates of the support contact email across different deployments.