### PR TITLE
Add GitHub Action for automatic clasp push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Google Apps Script
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18' # Or your preferred Node.js version
+
+      - name: Install clasp
+        run: npm install -g @google/clasp
+
+      - name: Create .clasprc.json
+        run: echo '${{ secrets.CLASPRC_JSON }}' > ~/.clasprc.json
+
+      - name: Push to Google Apps Script
+        run: clasp push


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automatically deploys the Google Apps Script project using clasp.

The workflow triggers on any push to the main branch. It performs the following steps:
1. Checks out the repository code.
2. Sets up Node.js.
3. Installs clasp globally.
4. Authenticates clasp using a CLASPRC_JSON secret stored in GitHub repository secrets. This secret contains the contents of the .clasprc.json file.
5. Pushes the code to the linked Google Apps Script project using 'clasp push'.

This automation will ensure that the Apps Script project is always up-to-date with the latest changes in the main branch.