### PR TITLE
feat: Update HTML interface with view toggle, filters, and enhanced UI

### DIFF
--- a/rubric.html
+++ b/rubric.html
@@ -504,6 +504,178 @@
                 font-size: 0.85rem;
             }
         }
+
+        /* View Toggle Button Styles */
+        .view-toggle-container {
+            margin-top: 15px;
+        }
+
+        .view-toggle-btn {
+            background: linear-gradient(135deg, #10b981, #059669);
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            font-weight: 600;
+            transition: all 0.3s ease;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        .view-toggle-btn:hover {
+            background: linear-gradient(135deg, #059669, #047857);
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+        }
+
+        .view-toggle-btn.assigned-mode {
+            background: linear-gradient(135deg, #f59e0b, #d97706);
+        }
+
+        .view-toggle-btn.assigned-mode:hover {
+            background: linear-gradient(135deg, #d97706, #b45309);
+        }
+
+        /* Special Role Filter Styles */
+        .special-filters {
+            background: #f8fafc;
+            border: 2px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 15px;
+        }
+
+        .filter-section {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .filter-label {
+            font-weight: 600;
+            color: #4a5568;
+            margin-right: 10px;
+        }
+
+        .filter-select {
+            background: white;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            padding: 8px 12px;
+            font-size: 0.9rem;
+            color: #374151;
+            min-width: 150px;
+        }
+
+        .filter-select:focus {
+            outline: none;
+            border-color: #3b82f6;
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .filter-btn {
+            background: #6b7280;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            padding: 8px 16px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: background 0.3s ease;
+        }
+
+        .filter-btn:hover {
+            background: #4b5563;
+        }
+
+        .domain-nav {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        /* Filter Status Indicator */
+        .filter-status {
+            background: #dbeafe;
+            border: 1px solid #3b82f6;
+            border-radius: 6px;
+            padding: 10px 15px;
+            margin-bottom: 15px;
+            color: #1e40af;
+            font-size: 0.9rem;
+            font-weight: 500;
+        }
+
+        .filter-status.active {
+            background: #fef3c7;
+            border-color: #f59e0b;
+            color: #92400e;
+        }
+
+        /* Component Assignment Indicators */
+        .component-assigned {
+            border-left: 4px solid #10b981 !important;
+            background: #f0fdf4 !important;
+        }
+
+        .component-not-assigned {
+            opacity: 0.6;
+            background: #f8fafc !important;
+            border-left: 4px solid #e5e7eb !important;
+        }
+
+        .assignment-indicator {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            background: #10b981;
+            color: white;
+            border-radius: 50%;
+            width: 20px;
+            height: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.7rem;
+            font-weight: bold;
+        }
+
+        .assignment-indicator.not-assigned {
+            background: #e5e7eb;
+            color: #6b7280;
+        }
+
+        /* Mobile Responsive Adjustments */
+        @media (max-width: 768px) {
+            .filter-section {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .filter-select {
+                min-width: auto;
+                width: 100%;
+                margin-bottom: 5px;
+            }
+
+            .view-toggle-btn {
+                width: 100%;
+                max-width: 300px;
+                margin: 0 auto;
+            }
+
+            .domain-nav {
+                flex-direction: column;
+            }
+
+            .nav-button {
+                width: 100%;
+                margin-bottom: 5px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -526,14 +698,90 @@
         <div class="header">
             <h1><?= data.title ?></h1>
             <p><?= data.subtitle ?></p>
+            <!-- View Mode Toggle (only for users with assigned subdomains) -->
+            <? if (data.userContext && data.userContext.assignedSubdomains && !data.userContext.hasSpecialAccess) { ?>
+            <div class="view-toggle-container">
+                <button id="viewToggleBtn" class="view-toggle-btn" onclick="toggleViewMode()">
+                    <span id="viewToggleText">
+                        <? if (data.userContext.viewMode === 'assigned') { ?>
+                            📋 View: My Assigned Areas
+                        <? } else { ?>
+                            📚 View: Full Rubric
+                        <? } ?>
+                    </span>
+                </button>
+            </div>
+            <? } ?>
         </div>
+
+        <!-- Filter Status (for special roles) -->
+        <? if (data.userContext && data.userContext.isFiltered) { ?>
+        <div class="filter-status active">
+            <strong>👁️ Viewing as:</strong> <?= data.userContext.filterInfo.viewingAs ?>
+            (<?= data.userContext.filterInfo.viewingRole ?>, Year <?= data.userContext.filterInfo.viewingYear ?>)
+            <span style="margin-left: 15px; font-size: 0.8rem;">
+                Requested by: <?= data.userContext.filterInfo.requestedBy ?>
+            </span>
+        </div>
+        <? } else if (data.userContext && data.userContext.hasSpecialAccess) { ?>
+        <div class="filter-status">
+            <strong>🔧 Special Access Mode:</strong> <?= data.userContext.specialRoleType.replace('_', ' ').toUpperCase() ?>
+            <span style="margin-left: 15px; font-size: 0.8rem;">
+                Use filters above to view other staff members' assigned areas
+            </span>
+        </div>
+        <? } ?>
         
         <div class="navigation">
-            <? for (var d = 0; d < data.domains.length; d++) { ?>
-                <button class="nav-button" data-domain="<?= d ?>">
-                    Domain <?= data.domains[d].number ?>
-                </button>
+            <!-- Special Role Filters -->
+            <? if (data.userContext && data.userContext.hasSpecialAccess) { ?>
+            <div class="special-filters">
+                <div class="filter-section">
+                    <span class="filter-label">Viewing Options:</span>
+
+                    <? if (data.userContext.specialRoleType === 'administrator') { ?>
+                    <!-- Administrator: Probationary filter only -->
+                    <select id="probationaryFilter" class="filter-select" onchange="applyAdminFilter()">
+                        <option value="all">All Staff</option>
+                        <option value="probationary">Probationary Staff Only</option>
+                    </select>
+
+                    <? } else if (data.userContext.specialRoleType === 'peer_evaluator' || data.userContext.specialRoleType === 'full_access') { ?>
+                    <!-- Peer Evaluator & Full Access: Full filtering options -->
+                    <select id="roleFilter" class="filter-select" onchange="updateAvailableStaff()">
+                        <option value="">Select Role...</option>
+                        <? for (var r = 0; r < data.userContext.availableRoles?.length || 0; r++) { ?>
+                        <option value="<?= data.userContext.availableRoles[r] ?>"><?= data.userContext.availableRoles[r] ?></option>
+                        <? } ?>
+                    </select>
+
+                    <select id="yearFilter" class="filter-select" onchange="updateAvailableStaff()">
+                        <option value="">Select Year...</option>
+                        <option value="1">Year 1</option>
+                        <option value="2">Year 2</option>
+                        <option value="3">Year 3</option>
+                        <option value="Probationary">Probationary</option>
+                    </select>
+
+                    <select id="staffFilter" class="filter-select" onchange="applyStaffFilter()">
+                        <option value="">Select Staff Member...</option>
+                        <!-- Options populated by JavaScript -->
+                    </select>
+
+                    <button class="filter-btn" onclick="clearAllFilters()">Clear Filters</button>
+                    <? } ?>
+                </div>
+            </div>
             <? } ?>
+
+            <!-- Domain Navigation (always visible) -->
+            <div class="domain-nav">
+                <? for (var d = 0; d < data.domains.length; d++) { ?>
+                    <button class="nav-button" data-domain="<?= d ?>">
+                        Domain <?= data.domains[d].number ?>
+                    </button>
+                <? } ?>
+            </div>
         </div>
         
         <? for (var domainIdx = 0; domainIdx < data.domains.length; domainIdx++) { ?>
@@ -554,26 +802,64 @@
                 </div>
                 
                 <? for (var i = 0; i < data.domains[domainIdx].components.length; i++) { ?>
-                    <div class="component-section">
+                    <?
+                    // Determine if this component should be visible
+                    var component = data.domains[domainIdx].components[i];
+                    var componentId = '';
+                    if (component.title) {
+                        var match = component.title.match(/^([1-4][a-f]):/);
+                        componentId = match ? match[1] + ':' : '';
+                    }
+
+                    var isAssigned = false;
+                    var shouldShow = true;
+
+                    if (data.userContext && data.userContext.assignedSubdomains && componentId) {
+                        var domainKey = 'domain' + (domainIdx + 1);
+                        var assignedList = data.userContext.assignedSubdomains[domainKey] || [];
+                        isAssigned = assignedList.indexOf(componentId) !== -1;
+
+                        // In assigned mode, only show assigned components
+                        if (data.userContext.viewMode === 'assigned') {
+                            shouldShow = isAssigned;
+                        }
+                    }
+                    ?>
+
+                    <? if (shouldShow) { ?>
+                    <div class="component-section <?= isAssigned ? 'component-assigned' : 'component-not-assigned' ?>"
+                         data-component-id="<?= componentId ?>"
+                         data-assigned="<?= isAssigned ? 'true' : 'false' ?>">
+
+                        <!-- Assignment Indicator -->
+                        <? if (data.userContext && data.userContext.assignedSubdomains && data.userContext.viewMode === 'full') { ?>
+                        <div class="assignment-indicator <?= isAssigned ? 'assigned' : 'not-assigned' ?>">
+                            <?= isAssigned ? '✓' : '○' ?>
+                        </div>
+                        <? } ?>
+
                         <div class="performance-levels-content">
                             <div class="row-label">
-                                <?= data.domains[domainIdx].components[i].title ?>
+                                <?= component.title ?>
+                                <? if (isAssigned && data.userContext && data.userContext.viewMode === 'assigned') { ?>
+                                <span class="assigned-badge">📋 Assigned</span>
+                                <? } ?>
                             </div>
                             <div class="level-content">
-                                <?= data.domains[domainIdx].components[i].developing ?>
+                                <?= component.developing ?>
                             </div>
                             <div class="level-content">
-                                <?= data.domains[domainIdx].components[i].basic ?>
+                                <?= component.basic ?>
                             </div>
                             <div class="level-content">
-                                <?= data.domains[domainIdx].components[i].proficient ?>
+                                <?= component.proficient ?>
                             </div>
                             <div class="level-content">
-                                <?= data.domains[domainIdx].components[i].distinguished ?>
+                                <?= component.distinguished ?>
                             </div>
                         </div>
                         
-                        <? if (data.domains[domainIdx].components[i].bestPractices && data.domains[domainIdx].components[i].bestPractices.length > 0) { ?>
+                        <? if (component.bestPractices && component.bestPractices.length > 0) { ?>
                         <div class="look-fors-section">
                             <div class="look-fors-header" onclick="toggleLookFors('domain-<?= domainIdx ?>-component-<?= i ?>')">
                                 <span>Best Practices aligned with 5D+ and PELSB Standards</span>
@@ -581,10 +867,10 @@
                             </div>
                             <div class="look-fors-content" id="lookForsContent-<?= domainIdx ?>-<?= i ?>">
                                 <div class="look-fors-grid">
-                                    <? for (var j = 0; j < data.domains[domainIdx].components[i].bestPractices.length; j++) { ?>
+                                    <? for (var j = 0; j < component.bestPractices.length; j++) { ?>
                                         <div class="look-for-item">
                                             <input type="checkbox" id="practice-<?= domainIdx ?>-<?= i ?>-<?= j ?>" name="practice-<?= domainIdx ?>-<?= i ?>-<?= j ?>">
-                                            <label for="practice-<?= domainIdx ?>-<?= i ?>-<?= j ?>"><?= data.domains[domainIdx].components[i].bestPractices[j] ?></label>
+                                            <label for="practice-<?= domainIdx ?>-<?= i ?>-<?= j ?>"><?= component.bestPractices[j] ?></label>
                                         </div>
                                     <? } ?>
                                 </div>
@@ -592,6 +878,7 @@
                         </div>
                         <? } ?>
                     </div>
+                    <? } ?>
                 <? } ?>
                 
                 <? if (!data.domains[domainIdx].components || data.domains[domainIdx].components.length === 0) { ?>


### PR DESCRIPTION
This commit implements Phase 4 of the HTML interface update, including:

1.  **View Toggle Button**: Added a button in the header for users with assigned subdomains to switch between "Full Rubric" and "My Assigned Areas" views. The button is not shown to users with special access roles.

2.  **Special Role Filter Controls**: The navigation section has been enhanced.
    - Administrators now see a "Probationary Staff Only" filter.
    - Peer Evaluators and Full Access roles have comprehensive filters for Role, Year, and Staff Member, along with a "Clear Filters" button.
    - These filters are only visible to users with `hasSpecialAccess`.
    - The standard domain navigation remains available for all users.

3.  **CSS Styling**: Added new CSS rules to style the view toggle button, special role filters, filter status indicators, component assignment visuals, and responsive adjustments for these elements.

4.  **Component Visibility Logic**: The rendering logic for components within domains has been updated:
    - Components are now aware of their assignment status based on `userContext.assignedSubdomains`.
    - In "Assigned Areas" view mode, only assigned components are shown.
    - In "Full Rubric" view mode, all components are shown, with visual indicators (e.g., border, icon) for assigned/unassigned status.
    - An "📋 Assigned" badge is shown next to component titles in assigned view.

5.  **Filter Status Display**: A new section has been added below the header to display the current filter status:
    - When a filter is active for special roles, it shows who is being viewed ("Viewing as: ...").
    - For special roles without an active filter, it indicates their special access mode and prompts to use filters.

These changes provide a more tailored and informative experience for different user roles, especially those with evaluation responsibilities, and improve the clarity of component assignments.