### PR TITLE
Refactor: Simplify conditions in Code.js

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -310,7 +310,7 @@ function handleStaffListRequest(e) {
     // Validate filterYear if provided
     if (filterYear) {
       const parsedFilterYear = parseInt(filterYear);
-      if (typeof parsedFilterYear !== 'number' || isNaN(parsedFilterYear) || !OBSERVATION_YEARS.includes(parsedFilterYear)) {
+      if (isNaN(parsedFilterYear) || !OBSERVATION_YEARS.includes(parsedFilterYear)) {
         return {
           success: false,
           error: 'Invalid input',
@@ -1205,7 +1205,7 @@ function enhanceDomainsWithAssignments(domains, assignedSubdomains, viewMode = '
         // Extract component ID from title
         const componentId = extractComponentId(component.title);
         // Check if componentId is valid and assignedList is not empty before .includes()
-        const isAssigned = componentId && assignedList.length > 0 ? assignedList.includes(componentId) : false;
+        const isAssigned = componentId ? assignedList.includes(componentId) : false;
 
         return {
           ...component,


### PR DESCRIPTION
I removed two redundant checks to improve code clarity and precision:

1. In `handleStaffListRequest`, I removed `typeof parsedFilterYear !== 'number'` from the `filterYear` validation. `isNaN(parsedFilterYear)` is sufficient as `parseInt` returns a number or NaN.

2. In `enhanceDomainsWithAssignments`, I removed `assignedList.length > 0` from the `isAssigned` check. `assignedList.includes()` correctly returns `false` for an empty array, and `assignedList` is guaranteed to be an array.