### PR TITLE
Fix: Align invalid year handling with invalid role handling

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1656,8 +1656,17 @@ function getAllDomainsData(role = null, year = null, viewMode = 'full', assigned
   if (year !== null && year !== undefined) {
     const observationYear = parseInt(year);
     if (isNaN(observationYear) || !OBSERVATION_YEARS.includes(observationYear)) {
-      console.warn(`Invalid year: ${year}. Proceeding without year filter.`);
-      // userYear remains null, effectively ignoring the invalid year
+      console.error(`Invalid year: ${year}. Returning error structure.`);
+      return {
+        title: "Error Loading Data",
+        subtitle: `Invalid year specified: ${year}. Please select a valid year. Valid years are: ${OBSERVATION_YEARS.join(', ')}.`,
+        role: userRole, // or the original 'role' param
+        year: year,     // original invalid year
+        viewMode: effectiveViewMode, // or original 'viewMode' param
+        domains: [],
+        isError: true,
+        errorMessage: `Invalid year: ${year}. Valid years are: ${OBSERVATION_YEARS.join(', ')}.`
+      };
     } else {
       userYear = observationYear;
     }


### PR DESCRIPTION
Previously, providing an invalid year to `getAllDomainsData` would result in a console warning and the system proceeding without a year filter. This change updates the behavior to be consistent with how invalid roles are handled.

Now, if an invalid year is provided, `getAllDomainsData` will return an error structure suitable for display in the UI. This provides clearer feedback to you and makes the API's error handling for filter parameters more consistent.

The returned error object includes:
- title: "Error Loading Data"
- subtitle: Explaining the error and listing valid years.
- role: The original role parameter.
- year: The invalid year parameter.
- viewMode: The original viewMode parameter.
- domains: An empty array.
- isError: true
- errorMessage: A message detailing the invalid year and valid options.