### PR TITLE
Refactor: Make invalid year error subtitle concise

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1659,7 +1659,7 @@ function getAllDomainsData(role = null, year = null, viewMode = 'full', assigned
       console.error(`Invalid year: ${year}. Returning error structure.`);
       return {
         title: "Error Loading Data",
-      subtitle: `Invalid year specified: ${year}. Please select a valid year. Valid years are: ${OBSERVATION_YEARS.join(', ')}`,
+          subtitle: `Invalid year specified: ${year}. Please select a valid year.`,
       role: role,
         year: year,     // original invalid year
       viewMode: viewMode,


### PR DESCRIPTION
The subtitle for an invalid year error was previously redundant with the errorMessage, both containing the list of valid years.

This change makes the subtitle more concise:
`Invalid year specified: ${year}. Please select a valid year.`

The errorMessage retains the full details, including the list of valid years: `Invalid year: ${year}. Valid years are: ${OBSERVATION_YEARS.join(', ')}`

This aligns the error messaging for invalid years with the existing pattern for invalid role errors, improving consistency.