### PR TITLE
Fix: Resolve merge conflict in getStaffListForDropdown

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -769,7 +769,6 @@ function getStaffListForDropdown(role, year) {
   try {
     debugLog(`getStaffListForDropdown called with role: ${role}, year: ${year}`);
 
-    // Assuming SheetService.getStaffData() is the canonical way to retrieve staff data.
     const staffData = SheetService.getStaffData();
 
     if (!staffData || !staffData.users || staffData.users.length === 0) {


### PR DESCRIPTION
A merge conflict arose because two branches (`feature/subdomain-parsing` and `Dynamic-subdomain-views`) had different ways of fetching staff data within the `getStaffListForDropdown` function in `Code.js`.

- `feature/subdomain-parsing` used `SheetService.getStaffData()`
- `Dynamic-subdomain-views` used `getStaffData()`

I resolved this by using `SheetService.getStaffData()`, as `SheetService.js` defines this function and it's used elsewhere in `Code.js`, indicating it's the standard method.