### PR TITLE
Fix: Remove duplicate VIEW_MODES declaration

### DIFF
--- a/Constants.js
+++ b/Constants.js
@@ -297,14 +297,6 @@ const VALIDATION_ERROR_TYPES = {
 };
 
 /**
- * View mode constants for subdomain filtering
- */
-const VIEW_MODES = {
-  FULL: 'full',
-  ASSIGNED: 'assigned'
-};
-
-/**
  * Special role types for filtering
  */
 const SPECIAL_ROLE_TYPES = {


### PR DESCRIPTION
I removed a duplicate declaration of the `VIEW_MODES` constant in `Constants.js`. This resolves a SyntaxError caused by the identifier being declared twice.