### PR TITLE
Fix: Ensure initializeFiltersFromURL is globally accessible

### DIFF
--- a/rubric.html
+++ b/rubric.html
@@ -553,7 +553,7 @@
             window.location.href = newUrl;
         }
 
-        function initializeFiltersFromURL() {
+        window.initializeFiltersFromURL = function() {
             const urlParams = new URLSearchParams(window.location.search);
 
             // Restore Administrator filter


### PR DESCRIPTION
I resolved an "Uncaught ReferenceError: initializeFiltersFromURL is not defined" error that occurred in rubric.html when served via Google Apps Script.

The error indicated that the function initializeFiltersFromURL, though defined within a <script> tag in the HTML, was not found in the accessible scope when called from the DOMContentLoaded event listener.

The fix involves changing the function definition from: `function initializeFiltersFromURL() { ... }`
to:
`window.initializeFiltersFromURL = function() { ... };`

This explicitly attaches the function to the global `window` object, ensuring it is accessible in the Google Apps Script HTML Service environment when invoked, thereby preventing the ReferenceError.