### PR TITLE
Fix: Move JavaScript functions from style to script block

### DIFF
--- a/rubric.html
+++ b/rubric.html
@@ -399,187 +399,6 @@
             }
         }
 
-        // Special Role Filter Functions
-
-        function applyAdminFilter() {
-            const filterSelect = document.getElementById('probationaryFilter');
-            if (!filterSelect) return;
-
-            const filterType = filterSelect.value;
-            console.log('Administrator filter applied:', filterType);
-
-            // Build new URL with filter parameter
-            const newUrl = generateFilteredURL({ filterType: filterType });
-            window.location.href = newUrl;
-        }
-
-        function updateAvailableStaff() {
-            const roleFilter = document.getElementById('roleFilter');
-            const yearFilter = document.getElementById('yearFilter');
-            const staffFilter = document.getElementById('staffFilter');
-
-            if (!roleFilter || !yearFilter || !staffFilter) return;
-
-            const selectedRole = roleFilter.value;
-            const selectedYear = yearFilter.value;
-
-            // Clear staff dropdown
-            staffFilter.innerHTML = '<option value="">Select Staff Member...</option>';
-
-            if (!selectedRole && !selectedYear) {
-                return;
-            }
-
-            // This would normally fetch from server, but for now we'll use a simple approach
-            console.log('Filters updated - Role:', selectedRole, 'Year:', selectedYear);
-
-            // Add a note that staff list will be populated when both role and year are selected
-            if (selectedRole && selectedYear) {
-                staffFilter.innerHTML = '<option value="">Loading staff...</option>';
-
-                // Trigger server request to get staff list
-                requestStaffList(selectedRole, selectedYear);
-            }
-        }
-
-        const DEFAULT_ERROR_MESSAGE = 'Server error. Please try again.';
-        function formatClientErrorMessage(error, defaultMessage = DEFAULT_ERROR_MESSAGE) {
-            let errorDetail = '';
-            if (error) {
-                if (error.message && typeof error.message === 'string' && error.message.trim()) {
-                    errorDetail = `: ${error.message.substring(0, 75)}`;
-                } else if (typeof error === 'string' && error.trim()) {
-                    errorDetail = `: ${error.substring(0, 75)}`;
-                }
-            }
-            if (!errorDetail) {
-                errorDetail = `: ${defaultMessage}`;
-            }
-            return errorDetail;
-        }
-
-        function requestStaffList(role, year) {
-            const staffFilter = document.getElementById('staffFilter');
-            if (!staffFilter) {
-                 console.error('Staff filter dropdown element not found in requestStaffList.');
-                 return;
-            }
-
-            // Indicate loading
-            staffFilter.innerHTML = ''; // Clear existing options first
-            const loadingOpt = new Option('Loading staff...', '');
-            loadingOpt.disabled = true;
-            staffFilter.appendChild(loadingOpt);
-            staffFilter.disabled = true;
-
-            console.log('Requesting staff list for role:', role, 'year:', year);
-
-            google.script.run
-                .withSuccessHandler(function(staffListData) {
-                    populateStaffDropdown(staffListData); // Pass only staffListData
-                    if (staffFilter) staffFilter.disabled = false;
-                })
-                .withFailureHandler(function(error) {
-                    console.error('Error fetching staff list:', error);
-                    if (staffFilter) {
-                        staffFilter.innerHTML = ''; // Clear existing options first
-                        const errorMessage = 'Error loading staff' + formatClientErrorMessage(error);
-                        const errorOpt = new Option(errorMessage, '');
-                        errorOpt.disabled = true;
-                        staffFilter.appendChild(errorOpt);
-                        staffFilter.disabled = false;
-                    }
-                })
-                .getStaffListForDropdown(role, year);
-        }
-
-        function populateStaffDropdown(staffListData) {
-            const staffFilter = document.getElementById('staffFilter');
-            if (!staffFilter) {
-                console.error('Staff filter dropdown element not found in populateStaffDropdown.');
-                return;
-            }
-
-            staffFilter.innerHTML = ''; // Clear existing options first
-            staffFilter.appendChild(new Option('Select Staff Member...', ''));
-
-            if (staffListData && Array.isArray(staffListData)) {
-                if (staffListData.length === 0) {
-                    const noStaffOption = new Option('No staff found for this selection', '');
-                    noStaffOption.disabled = true;
-                    staffFilter.appendChild(noStaffOption);
-                } else {
-                    staffListData.forEach(function(staff) {
-                        if (typeof staff === 'object' && staff !== null &&
-                            typeof staff.name === 'string' && staff.name.trim() !== '' &&
-                            typeof staff.email === 'string' && staff.email.trim() !== '') {
-                            const option = document.createElement('option');
-                            option.value = staff.email;
-                            option.textContent = staff.name;
-                            staffFilter.appendChild(option);
-                        } else {
-                            console.warn('Invalid or incomplete staff item found in list. Skipping:', staff);
-                        }
-                    });
-                }
-                console.log('Staff dropdown populated with', staffListData.length, 'staff members.');
-            } else {
-                console.error('Failed to populate staff dropdown due to invalid or missing staffListData:', staffListData);
-                const errorOption = new Option('Error loading staff data', '');
-                errorOption.disabled = true;
-                staffFilter.appendChild(errorOption);
-            }
-        }
-
-        function applyStaffFilter() {
-            const staffFilter = document.getElementById('staffFilter');
-            if (!staffFilter) return;
-
-            const selectedStaff = staffFilter.value;
-            if (!selectedStaff) return;
-
-            console.log('Staff filter applied:', selectedStaff);
-
-            // Redirect to view as selected staff member
-            const newUrl = generateFilteredURL({ filterStaff: selectedStaff, view: 'assigned' });
-            window.location.href = newUrl;
-        }
-
-        function clearAllFilters() {
-            console.log('Clearing all filters');
-
-            // Build URL without filter parameters
-            const newUrl = generateFilteredURL({});
-            window.location.href = newUrl;
-        }
-
-        window.initializeFiltersFromURL = function() {
-            const urlParams = new URLSearchParams(window.location.search);
-
-            // Restore Administrator filter
-            const probationaryFilter = document.getElementById('probationaryFilter');
-            if (probationaryFilter && urlParams.get('filterType')) {
-                probationaryFilter.value = urlParams.get('filterType');
-            }
-
-            // Restore role/year filters
-            const roleFilter = document.getElementById('roleFilter');
-            const yearFilter = document.getElementById('yearFilter');
-
-            if (roleFilter && urlParams.get('filterRole')) {
-                roleFilter.value = urlParams.get('filterRole');
-            }
-
-            if (yearFilter && urlParams.get('filterYear')) {
-                yearFilter.value = urlParams.get('filterYear');
-            }
-
-            // Update staff list if both role and year are set
-            if (roleFilter && yearFilter && roleFilter.value && yearFilter.value) {
-                updateAvailableStaff();
-            }
-        }
-
         /* Debug info styles (only visible in debug mode) */
         <? if (data.userContext && data.userContext.debugMode) { ?>
         .debug-info {
@@ -1208,6 +1027,186 @@
     </div>
 
     <script>
+        // Special Role Filter Functions
+        function applyAdminFilter() {
+            const filterSelect = document.getElementById('probationaryFilter');
+            if (!filterSelect) return;
+
+            const filterType = filterSelect.value;
+            console.log('Administrator filter applied:', filterType);
+
+            // Build new URL with filter parameter
+            const newUrl = generateFilteredURL({ filterType: filterType });
+            window.location.href = newUrl;
+        }
+
+        function updateAvailableStaff() {
+            const roleFilter = document.getElementById('roleFilter');
+            const yearFilter = document.getElementById('yearFilter');
+            const staffFilter = document.getElementById('staffFilter');
+
+            if (!roleFilter || !yearFilter || !staffFilter) return;
+
+            const selectedRole = roleFilter.value;
+            const selectedYear = yearFilter.value;
+
+            // Clear staff dropdown
+            staffFilter.innerHTML = '<option value="">Select Staff Member...</option>';
+
+            if (!selectedRole && !selectedYear) {
+                return;
+            }
+
+            // This would normally fetch from server, but for now we'll use a simple approach
+            console.log('Filters updated - Role:', selectedRole, 'Year:', selectedYear);
+
+            // Add a note that staff list will be populated when both role and year are selected
+            if (selectedRole && selectedYear) {
+                staffFilter.innerHTML = '<option value="">Loading staff...</option>';
+
+                // Trigger server request to get staff list
+                requestStaffList(selectedRole, selectedYear);
+            }
+        }
+
+        const DEFAULT_ERROR_MESSAGE = 'Server error. Please try again.';
+        function formatClientErrorMessage(error, defaultMessage = DEFAULT_ERROR_MESSAGE) {
+            let errorDetail = '';
+            if (error) {
+                if (error.message && typeof error.message === 'string' && error.message.trim()) {
+                    errorDetail = `: ${error.message.substring(0, 75)}`;
+                } else if (typeof error === 'string' && error.trim()) {
+                    errorDetail = `: ${error.substring(0, 75)}`;
+                }
+            }
+            if (!errorDetail) {
+                errorDetail = `: ${defaultMessage}`;
+            }
+            return errorDetail;
+        }
+
+        function requestStaffList(role, year) {
+            const staffFilter = document.getElementById('staffFilter');
+            if (!staffFilter) {
+                 console.error('Staff filter dropdown element not found in requestStaffList.');
+                 return;
+            }
+
+            // Indicate loading
+            staffFilter.innerHTML = ''; // Clear existing options first
+            const loadingOpt = new Option('Loading staff...', '');
+            loadingOpt.disabled = true;
+            staffFilter.appendChild(loadingOpt);
+            staffFilter.disabled = true;
+
+            console.log('Requesting staff list for role:', role, 'year:', year);
+
+            google.script.run
+                .withSuccessHandler(function(staffListData) {
+                    populateStaffDropdown(staffListData); // Pass only staffListData
+                    if (staffFilter) staffFilter.disabled = false;
+                })
+                .withFailureHandler(function(error) {
+                    console.error('Error fetching staff list:', error);
+                    if (staffFilter) {
+                        staffFilter.innerHTML = ''; // Clear existing options first
+                        const errorMessage = 'Error loading staff' + formatClientErrorMessage(error);
+                        const errorOpt = new Option(errorMessage, '');
+                        errorOpt.disabled = true;
+                        staffFilter.appendChild(errorOpt);
+                        staffFilter.disabled = false;
+                    }
+                })
+                .getStaffListForDropdown(role, year);
+        }
+
+        function populateStaffDropdown(staffListData) {
+            const staffFilter = document.getElementById('staffFilter');
+            if (!staffFilter) {
+                console.error('Staff filter dropdown element not found in populateStaffDropdown.');
+                return;
+            }
+
+            staffFilter.innerHTML = ''; // Clear existing options first
+            staffFilter.appendChild(new Option('Select Staff Member...', ''));
+
+            if (staffListData && Array.isArray(staffListData)) {
+                if (staffListData.length === 0) {
+                    const noStaffOption = new Option('No staff found for this selection', '');
+                    noStaffOption.disabled = true;
+                    staffFilter.appendChild(noStaffOption);
+                } else {
+                    staffListData.forEach(function(staff) {
+                        if (typeof staff === 'object' && staff !== null &&
+                            typeof staff.name === 'string' && staff.name.trim() !== '' &&
+                            typeof staff.email === 'string' && staff.email.trim() !== '') {
+                            const option = document.createElement('option');
+                            option.value = staff.email;
+                            option.textContent = staff.name;
+                            staffFilter.appendChild(option);
+                        } else {
+                            console.warn('Invalid or incomplete staff item found in list. Skipping:', staff);
+                        }
+                    });
+                }
+                console.log('Staff dropdown populated with', staffListData.length, 'staff members.');
+            } else {
+                console.error('Failed to populate staff dropdown due to invalid or missing staffListData:', staffListData);
+                const errorOption = new Option('Error loading staff data', '');
+                errorOption.disabled = true;
+                staffFilter.appendChild(errorOption);
+            }
+        }
+
+        function applyStaffFilter() {
+            const staffFilter = document.getElementById('staffFilter');
+            if (!staffFilter) return;
+
+            const selectedStaff = staffFilter.value;
+            if (!selectedStaff) return;
+
+            console.log('Staff filter applied:', selectedStaff);
+
+            // Redirect to view as selected staff member
+            const newUrl = generateFilteredURL({ filterStaff: selectedStaff, view: 'assigned' });
+            window.location.href = newUrl;
+        }
+
+        function clearAllFilters() {
+            console.log('Clearing all filters');
+
+            // Build URL without filter parameters
+            const newUrl = generateFilteredURL({});
+            window.location.href = newUrl;
+        }
+
+        window.initializeFiltersFromURL = function() {
+            const urlParams = new URLSearchParams(window.location.search);
+
+            // Restore Administrator filter
+            const probationaryFilter = document.getElementById('probationaryFilter');
+            if (probationaryFilter && urlParams.get('filterType')) {
+                probationaryFilter.value = urlParams.get('filterType');
+            }
+
+            // Restore role/year filters
+            const roleFilter = document.getElementById('roleFilter');
+            const yearFilter = document.getElementById('yearFilter');
+
+            if (roleFilter && urlParams.get('filterRole')) {
+                roleFilter.value = urlParams.get('filterRole');
+            }
+
+            if (yearFilter && urlParams.get('filterYear')) {
+                yearFilter.value = urlParams.get('filterYear');
+            }
+
+            // Update staff list if both role and year are set
+            if (roleFilter && yearFilter && roleFilter.value && yearFilter.value) {
+                updateAvailableStaff();
+            }
+        }
+
         // Enhanced cache busting and page management
 
         // Prevent browser caching of this page


### PR DESCRIPTION
I moved several JavaScript functions (applyAdminFilter, updateAvailableStaff, etc.) from the `<style>` block to the beginning of the `<script>` block in rubric.html.

This corrects their erroneous placement, ensuring they are parsed and executed as JavaScript and not as CSS.