### PR TITLE
Fix: Correct _isUserYearMatching logic for invalid inputs

### DIFF
--- a/Utils.js
+++ b/Utils.js
@@ -404,19 +404,40 @@ function getAssignedSubdomainsForRoleYear(role, year) {
  * @private
  */
 function _isUserYearMatching(userYear, targetYear) {
-  // Parse both years using the enhanced parser
+  // Handle cases where inputs might not be strings, or to normalize before strict check
+  // Ensure that null or undefined inputs are treated as empty strings for initial comparison,
+  // as parseYearValue itself handles null/undefined by returning null.
+  const sUserYearInput = (userYear === null || userYear === undefined) ? "" : String(userYear);
+  const sTargetYearInput = (targetYear === null || targetYear === undefined) ? "" : String(targetYear);
+
+  // Trim the string inputs for comparison.
+  const sUserYear = sUserYearInput.trim();
+  const sTargetYear = sTargetYearInput.trim();
+
+  // If the string representations (trimmed, case-insensitive) are identical, they match.
+  // This handles "foo" vs "foo", "" vs "", "1" vs "1".
+  if (sUserYear.toLowerCase() === sTargetYear.toLowerCase()) {
+    return true;
+  }
+
+  // We need parseYearValue for the semantic comparison.
+  // Assume parseYearValue is defined elsewhere and accessible.
   const parsedUserYear = parseYearValue(userYear);
   const parsedTargetYear = parseYearValue(targetYear);
 
-  // Handle null cases
+  // At this point, the original string values (after trimming and case change) were different.
+  // If both parse to null, it means they were different *unparseable* strings. So, no match.
   if (parsedUserYear === null && parsedTargetYear === null) {
-    return true; // Both are null/invalid
-  }
-  
-  if (parsedUserYear === null || parsedTargetYear === null) {
-    return false; // One is null, the other isn't
+    return false;
   }
 
-  // Direct comparison of parsed numeric values
+  // If one parsed to null and the other didn't (and originals were different), they don't match.
+  if (parsedUserYear === null || parsedTargetYear === null) {
+    return false;
+  }
+
+  // Both parsed to valid, non-null years, and original string forms were different
+  // (e.g., "Year 1" vs "1" which parse to the same numeric year).
+  // Compare the numeric results of parsing.
   return parsedUserYear === parsedTargetYear;
 }


### PR DESCRIPTION
The _isUserYearMatching function in Utils.js previously considered two different invalid year strings (e.g., an empty string and "garbage") as a match because both would parse to `null` via `parseYearValue`, and `null === null` is true.

This change updates `_isUserYearMatching` to:
1. First, perform a case-insensitive comparison of the trimmed string representations of the input years. If identical (e.g., "" vs "", or "foo" vs "foo"), return `true`.
2. If the string inputs are different, then parse both using `parseYearValue`.
3. If both parsed results are `null` (meaning different unparseable inputs like "" vs "garbage"), return `false`.
4. If one parsed result is `null` and the other isn't, return `false`.
5. Otherwise (both parsed to non-null, potentially different original strings like "Year 1" and "1"), compare the parsed numeric values.

This ensures that distinct invalid/unparseable year inputs do not match, while identical inputs (valid or invalid) and semantically equivalent valid years (e.g. "Year 1" and 1) continue to match correctly.

The `parseYearValue` function, which `_isUserYearMatching` depends on, is located in `SheetService.js`. No changes were made to `parseYearValue` itself.