### PR TITLE
Fix: Make all roles in probationary list clickable

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2432,6 +2432,7 @@ function createFilterSelectionInterface(userContext, requestId) {
         
         // Pass data to the template
         htmlTemplate.userContext = userContext;
+        htmlTemplate.userContext.probationaryYearValue = PROBATIONARY_OBSERVATION_YEAR;
         htmlTemplate.availableRoles = AVAILABLE_ROLES;
         htmlTemplate.availableYears = OBSERVATION_YEARS;
 

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -1070,6 +1070,7 @@
         }
 
         function generateProbationaryStaffHtml(data) {
+            const probationaryYear = <?= userContext.probationaryYearValue ?>;
             let html = `
                 <div style="background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 20px rgba(0,0,0,0.1);">
                     <div style="background: linear-gradient(135deg, #dc2626, #b91c1c); color: white; padding: 30px; text-align: center;">
@@ -1082,13 +1083,17 @@
             if (data.staff && data.staff.length > 0) {
                 html += '<div style="display: grid; gap: 15px;">';
                 data.staff.forEach(function(staff) {
+                    // Make all staff members clickable
+                    const onclickAttribute = `onclick="loadStaffMemberRubric('${staff.email}', '${staff.role}', ${staff.year})"`;
+                    const cursorStyle = 'cursor: pointer;';
+
                     html += `
-                        <div style="background: #fef2f2; border: 2px solid #fecaca; border-radius: 8px; padding: 20px;">
+                        <div style="background: #fef2f2; border: 2px solid #fecaca; border-radius: 8px; padding: 20px; ${cursorStyle}" ${onclickAttribute}>
                             <h4 style="margin: 0 0 10px 0; color: #dc2626; font-size: 1.1rem;">${staff.name || 'Unknown Name'}</h4>
                             <div style="color: #7f1d1d; font-size: 0.95rem;">
                                 <div><strong>Email:</strong> ${staff.email || 'No email'}</div>
                                 <div><strong>Role:</strong> ${staff.role || 'Unknown Role'}</div>
-                                <div><strong>Year:</strong> ${staff.year || 'Unknown Year'}</div>
+                                <div><strong>Year:</strong> ${staff.year === probationaryYear ? 'Probationary' : (staff.year || 'Unknown Year')}</div>
                             </div>
                         </div>
                     `;
@@ -1263,6 +1268,23 @@
             specialRoleType: '<?= userContext.specialRoleType ?>',
             year: <?= userContext.year || 1 ?>
         });
+
+        function loadStaffMemberRubric(email, role, year) {
+            // Attempt to load rubric for any role
+            showLoading(`Loading ${role} rubric...`); // More generic message
+            const filterParams = {
+                role: role,
+                year: year,
+                staff: email,
+                viewType: 'assigned' // Default to assigned areas for a specific staff member
+            };
+            google.script.run
+                .withSuccessHandler(handleRubricData)
+                .withFailureHandler(handleError)
+                .loadRubricData(filterParams);
+            console.log(`Attempting to load rubric for ${email}, Role: ${role}, Year: ${year}`);
+        }
+
         // Function to toggle look-fors sections (copied from main rubric)
         function toggleLookFors(componentId) {
             const parts = componentId.split('-');


### PR DESCRIPTION
- Modifies the probationary staff list in `filter-interface.html` so that all staff members are clickable, not just those with the 'Teacher' role.
- Clicking any staff member in this list will now attempt to load their rubric based on their actual role and year.
- The `loadStaffMemberRubric` (formerly `loadTeacherRubric`) client-side function was updated to remove the role check.
- This addresses your feedback requiring all roles in the list to be interactive.