### PR TITLE
fix(rubric): Remove duplicate variable declaration

### DIFF
--- a/rubric.html
+++ b/rubric.html
@@ -2428,7 +2428,6 @@
         });
 
         // --- Observation Management ---
-        let currentObservationId = null;
 
         function beginObservation() {
             const observeeEmail = document.getElementById('staffFilter').value;


### PR DESCRIPTION
Removes a redundant declaration of the 'currentObservationId' variable in rubric.html.

The duplicate 'let' statement caused a SyntaxError, which prevented the client-side JavaScript from executing and resulted in reference errors, particularly for the Peer Evaluator role. This change ensures the script can be parsed and executed correctly.