### PR TITLE
I've identified that the slow loading times were caused by overly agg…

### DIFF
--- a/Constants.js
+++ b/Constants.js
@@ -119,9 +119,9 @@ const ERROR_MESSAGES = {
  * Cache settings for performance optimization
  */
 const CACHE_SETTINGS = {
-  USER_DATA_TTL: 300,        // 5 minutes for user data
+  USER_DATA_TTL: 14400,      // 4 hours for user data
   ROLE_CONFIG_TTL: 600,      // 10 minutes for role configurations
-  SHEET_DATA_TTL: 180,       // 3 minutes for sheet data
+  SHEET_DATA_TTL: 14400,     // 4 hours for sheet data
   DEFAULT_TTL: 300           // Default cache time
 };
 

--- a/Constants.js
+++ b/Constants.js
@@ -118,11 +118,13 @@ const ERROR_MESSAGES = {
 /**
  * Cache settings for performance optimization
  */
+const FOUR_HOURS_IN_SECONDS = 14400; // 4 hours = 4 * 60 * 60 seconds
+
 const CACHE_SETTINGS = {
-  USER_DATA_TTL: 14400,      // 4 hours for user data
-  ROLE_CONFIG_TTL: 600,      // 10 minutes for role configurations
-  SHEET_DATA_TTL: 14400,     // 4 hours for sheet data
-  DEFAULT_TTL: 300           // Default cache time
+  USER_DATA_TTL: FOUR_HOURS_IN_SECONDS,      // 4 hours for user data - improves performance by reducing frequent spreadsheet reads
+  ROLE_CONFIG_TTL: 600,                      // 10 minutes for role configurations
+  SHEET_DATA_TTL: FOUR_HOURS_IN_SECONDS,     // 4 hours for sheet data - improves performance by reducing frequent spreadsheet reads
+  DEFAULT_TTL: 300                           // Default cache time
 };
 
 /**


### PR DESCRIPTION
…ressive cache expiration. The Time-To-Live (TTL) for sheet and user data was set to 3-5 minutes, forcing frequent and slow re-fetches from the source Google Sheet.

I have increased the TTL for `SHEET_DATA_TTL` and `USER_DATA_TTL` to 4 hours (14400 seconds). This will significantly improve performance by ensuring that data remains in the cache for a longer period, reducing the number of slow spreadsheet reads that you experience.