### PR TITLE
feat: Polish observation view UI and add Best Practices

### DIFF
--- a/filter-interface.html
+++ b/filter-interface.html
@@ -5,56 +5,92 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= userContext.role ?> - Select Rubric View</title>
     <style>
+:root {
+    --color-white: white;
+    --color-text-default: #333;
+    --color-bg-body: #f5f5f5;
+
+    /* Greens for toggle button and assignments */
+    --color-green-base: #10b981;
+    --color-green-dark: #059669;
+    --color-green-darker: #047857;
+    --color-green-light-bg: #f0fdf4;
+
+    /* Ambers for toggle button (assigned mode) and active filters */
+    --color-amber-base: #f59e0b;
+    --color-amber-dark: #d97706;
+    --color-amber-darker: #b45309;
+    --color-amber-light-bg: #fef3c7;
+    --color-amber-text-dark: #92400e;
+
+    /* Blues for filter status and select focus */
+    --color-blue-base: #3b82f6;
+    --color-blue-light-bg: #dbeafe;
+    --color-blue-text-dark: #1e40af;
+    --color-blue-focus-shadow: rgba(59, 130, 246, 0.1);
+
+    /* Grays for various UI elements */
+    --color-gray-text: #4a5568;
+    --color-gray-text-light: #374151;
+    --color-gray-border-light: #d1d5db;
+    --color-gray-border-medium: #e2e8f0;
+    --color-gray-bg-light: #f8fafc;
+    --color-gray-bg-medium: #6b7280;
+    --color-gray-bg-dark: #4b5563;
+    --color-gray-component-not-assigned-border: #e5e7eb;
+    --color-gray-assignment-indicator-not-assigned-bg: #e5e7eb;
+    --color-text-deemphasized: #718096;
+}
+
         * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #f5f5f5;
+            background: var(--color-bg-body);
             padding: 20px;
             line-height: 1.6;
+            color: var(--color-text-default);
         }
-        
+
         .container {
-            max-width: 900px;
+            max-width: 1200px;
             margin: 0 auto;
-            background: white;
+            background: var(--color-white);
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.1);
             overflow: hidden;
         }
-        
+
         .header {
             background: linear-gradient(135deg, #4a5568, #2d3748);
-            color: white;
+            color: var(--color-white);
             padding: 40px 30px;
             text-align: center;
         }
-        
+
         .header h1 {
             font-size: 2rem;
             margin-bottom: 10px;
             font-weight: 600;
         }
-        
+
         .header p {
             font-size: 1.1rem;
             opacity: 0.9;
         }
-        
+
         .content {
             padding: 40px 30px;
         }
-        
-        .quick-actions {
-            margin-bottom: 40px;
-        }
-        
+
+        /* Dashboard-specific styles */
+        .quick-actions { margin-bottom: 40px; }
         .section-title {
-            color: #4a5568;
+            color: var(--color-gray-text);
             font-size: 1.3rem;
             font-weight: 600;
             margin-bottom: 20px;
@@ -62,16 +98,14 @@
             align-items: center;
             gap: 10px;
         }
-        
         .actions-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
             gap: 20px;
         }
-        
         .action-card {
-            background: white;
-            border: 2px solid #e2e8f0;
+            background: var(--color-white);
+            border: 2px solid var(--color-gray-border-medium);
             border-radius: 12px;
             padding: 25px;
             text-align: center;
@@ -79,152 +113,68 @@
             transition: all 0.3s ease;
             position: relative;
         }
-        
         .action-card:hover {
-            border-color: #3182ce;
-            background: #f7fafc;
+            border-color: var(--color-blue-base);
+            background: var(--color-gray-bg-light);
             transform: translateY(-2px);
             box-shadow: 0 8px 25px rgba(0,0,0,0.1);
         }
-        
-        .action-icon {
-            font-size: 2.5rem;
-            margin-bottom: 15px;
-            display: block;
-        }
-        
-        .action-title {
-            font-weight: 600;
-            color: #2d3748;
-            font-size: 1.1rem;
-            margin-bottom: 8px;
-        }
-        
-        .action-desc {
-            color: #718096;
-            font-size: 0.95rem;
-        }
-        
+        .action-icon { font-size: 2.5rem; margin-bottom: 15px; display: block; }
+        .action-title { font-weight: 600; color: #2d3748; font-size: 1.1rem; margin-bottom: 8px; }
+        .action-desc { color: var(--color-text-deemphasized); font-size: 0.95rem; }
+
+        /* Filter controls */
         .custom-filters, .observation-selector {
-            background: #f8fafc;
-            border: 2px solid #e2e8f0;
+            background: var(--color-gray-bg-light);
+            border: 2px solid var(--color-gray-border-medium);
             border-radius: 12px;
             padding: 30px;
             display: none;
         }
-        
-        .filter-row {
-            display: flex;
-            gap: 15px;
-            margin-bottom: 20px;
-            align-items: center;
-            flex-wrap: wrap;
-        }
-        
-        .filter-select, .filter-btn {
+        .filter-row { display: flex; gap: 15px; margin-bottom: 20px; align-items: center; flex-wrap: wrap; }
+        .filter-select {
             padding: 12px 15px;
-            border: 2px solid #e2e8f0;
+            border: 1px solid var(--color-gray-border-light);
             border-radius: 8px;
             font-size: 1rem;
-            background: white;
+            background: var(--color-white);
             transition: all 0.3s ease;
-        }
-        
-        .filter-select {
             flex: 1;
             min-width: 200px;
         }
-        
         .filter-select:focus {
             outline: none;
-            border-color: #3182ce;
-            box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.1);
+            border-color: var(--color-blue-base);
+            box-shadow: 0 0 0 3px var(--color-blue-focus-shadow);
         }
-        
         .filter-btn {
-            background: #3182ce;
-            color: white;
-            border: 2px solid #3182ce;
+            background: var(--color-blue-base);
+            color: var(--color-white);
+            border: 2px solid var(--color-blue-base);
             cursor: pointer;
             font-weight: 600;
             min-width: 140px;
-        }
-        
-        .filter-btn:hover:not(:disabled) {
-            background: #2c5aa0;
-            border-color: #2c5aa0;
-        }
-        
-        .filter-btn:disabled {
-            background: #cbd5e0;
-            border-color: #cbd5e0;
-            cursor: not-allowed;
-        }
-        
-        .btn-secondary {
-            background: #6b7280;
-            border-color: #6b7280;
-        }
-        
-        .btn-secondary:hover {
-            background: #4b5563;
-            border-color: #4b5563;
-        }
-        
-        .loading, .error {
-            text-align: center;
-            padding: 40px;
-            margin: 20px 0;
-            border-radius: 12px;
-            display: none;
-        }
-        
-        .loading {
-            background: #f0f9ff;
-            color: #0369a1;
-            border: 2px solid #bae6fd;
-        }
-        
-        .error {
-            background: #fef2f2;
-            color: #dc2626;
-            border: 2px solid #fecaca;
-        }
-        
-        .loading-spinner {
-            display: inline-block;
-            width: 30px;
-            height: 30px;
-            border: 3px solid rgba(3, 105, 161, 0.3);
-            border-radius: 50%;
-            border-top-color: #0369a1;
-            animation: spin 1s ease-in-out infinite;
-            margin-right: 10px;
-        }
-        
-        @keyframes spin {
-            to { transform: rotate(360deg); }
-        }
-        
-        .filter-status {
-            background: #dbeafe;
-            border: 2px solid #3b82f6;
+            padding: 12px 15px;
             border-radius: 8px;
-            padding: 15px;
-            margin-bottom: 20px;
-            color: #1e40af;
-            font-weight: 500;
-            display: none;
+            font-size: 1rem;
+            transition: all 0.3s ease;
         }
-        
-        .rubric-container {
-            display: none;
-            margin-top: 30px;
-        }
-        
+        .filter-btn:hover:not(:disabled) { background: #2c5aa0; border-color: #2c5aa0; }
+        .filter-btn:disabled { background: #cbd5e0; border-color: #cbd5e0; cursor: not-allowed; }
+        .btn-secondary { background: var(--color-gray-bg-medium); border-color: var(--color-gray-bg-medium); }
+        .btn-secondary:hover { background: var(--color-gray-bg-dark); border-color: var(--color-gray-bg-dark); }
+
+        /* Loading and Error states */
+        .loading, .error { text-align: center; padding: 40px; margin: 20px 0; border-radius: 12px; display: none; }
+        .loading { background: var(--color-blue-light-bg); color: var(--color-blue-text-dark); border: 2px solid var(--color-blue-base); }
+        .error { background: #fef2f2; color: #dc2626; border: 2px solid #fecaca; }
+        .loading-spinner { display: inline-block; width: 30px; height: 30px; border: 3px solid rgba(59, 130, 246, 0.3); border-radius: 50%; border-top-color: var(--color-blue-base); animation: spin 1s ease-in-out infinite; margin-right: 10px; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        /* Observation cards */
         .observation-card {
-            background: white;
-            border: 1px solid #e2e8f0;
+            background: var(--color-white);
+            border: 1px solid var(--color-gray-border-medium);
             border-radius: 12px;
             padding: 0;
             text-align: left;
@@ -232,122 +182,106 @@
             display: flex;
             flex-direction: column;
         }
-        .observation-card:hover {
-            box-shadow: 0 8px 25px rgba(0,0,0,0.08);
-            transform: translateY(-2px);
-        }
-        .obs-card-content {
-            padding: 20px;
-            flex-grow: 1;
-        }
-        .obs-card-title {
-            font-weight: 600;
-            color: #2d3748;
-            font-size: 1.1rem;
-            margin-bottom: 4px;
-        }
-        .obs-card-desc {
-            color: #718096;
-            font-size: 0.9rem;
-            margin-bottom: 12px;
-        }
-        .status-badge {
-            display: inline-block;
-            padding: 4px 10px;
-            font-size: 0.8rem;
-            font-weight: 600;
-            border-radius: 9999px;
-        }
-        .status-draft { background-color: #feefc7; color: #8c5d02; }
-        .status-finalized { background-color: #dcfce7; color: #166534; }
-        .obs-card-actions {
-            background: #f8fafc;
-            border-top: 1px solid #e2e8f0;
-            padding: 15px 20px;
-            display: flex;
-            gap: 10px;
-            justify-content: flex-end;
-        }
-        .obs-card-actions .filter-btn {
-            padding: 8px 16px;
-            font-size: 0.9rem;
-            min-width: auto;
-        }
+        .observation-card:hover { box-shadow: 0 8px 25px rgba(0,0,0,0.08); transform: translateY(-2px); }
+        .obs-card-content { padding: 20px; flex-grow: 1; }
+        .obs-card-title { font-weight: 600; color: #2d3748; font-size: 1.1rem; margin-bottom: 4px; }
+        .obs-card-desc { color: var(--color-text-deemphasized); font-size: 0.9rem; margin-bottom: 12px; }
+        .status-badge { display: inline-block; padding: 4px 10px; font-size: 0.8rem; font-weight: 600; border-radius: 9999px; }
+        .status-draft { background-color: var(--color-amber-light-bg); color: var(--color-amber-text-dark); }
+        .status-finalized { background-color: var(--color-green-light-bg); color: #166534; }
+        .obs-card-actions { background: var(--color-gray-bg-light); border-top: 1px solid var(--color-gray-border-medium); padding: 15px 20px; display: flex; gap: 10px; justify-content: flex-end; }
+        .obs-card-actions .filter-btn { padding: 8px 16px; font-size: 0.9rem; min-width: auto; }
         .btn-edit { background: #3b82f6; border-color: #3b82f6; }
         .btn-edit:hover { background: #2563eb; border-color: #2563eb; }
-        .btn-finalize { background: #16a34a; border-color: #16a34a; }
-        .btn-finalize:hover { background: #15803d; border-color: #15803d; }
+        .btn-finalize { background: var(--color-green-base); border-color: var(--color-green-base); }
+        .btn-finalize:hover { background: var(--color-green-dark); border-color: var(--color-green-dark); }
         .btn-delete { background: #dc2626; border-color: #dc2626; }
         .btn-delete:hover { background: #b91c1c; border-color: #b91c1c; }
 
-
-        @media (max-width: 768px) {
-            .content {
-                padding: 20px;
-            }
-            .actions-grid {
-                grid-template-columns: 1fr;
-            }
-            .filter-row {
-                flex-direction: column;
-                align-items: stretch;
-            }
-            .filter-select, .filter-btn {
-                min-width: auto;
-                width: 100%;
-            }
-        }
-
-        /* === Styles for Interactive Rubric === */
-        .domain-section { border-bottom: 3px solid #e2e8f0; }
+        /* === Rubric Styles (from rubric.html) === */
+        .rubric-container { display: none; margin-top: 30px; }
+        .domain-section { border-bottom: 3px solid var(--color-gray-border-medium); }
         .domain-header { background: linear-gradient(135deg, #7c9ac5, #5a82b8); color: white; padding: 15px 20px; font-size: 1.1rem; font-weight: 600; position: sticky; top: 0; z-index: 50; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
-        .component-section { border-bottom: 1px solid #e2e8f0; position: relative; transition: display 0.3s ease, background-color 0.2s; }
-        .component-hidden { display: none; }
-        .performance-levels-header { position: sticky; top: 56px; z-index: 40; background: white; border-bottom: 2px solid #e2e8f0; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+        .component-section { border-bottom: 1px solid var(--color-gray-border-medium); position: relative; transition: background-color 0.2s; }
+        .performance-levels-header { position: sticky; top: 56px; z-index: 40; background: white; border-bottom: 2px solid var(--color-gray-border-medium); box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
         .performance-levels { display: grid; grid-template-columns: 200px 1fr 1fr 1fr 1fr; min-height: 50px; }
         .performance-levels-content { display: grid; grid-template-columns: 200px 1fr 1fr 1fr 1fr; min-height: 120px; }
-        .level-header { background: #e2e8f0; padding: 12px; font-weight: 600; text-align: center; border-bottom: 1px solid #cbd5e0; color: #4a5568; font-size: 0.9rem; }
-        .level-content { padding: 20px; border-right: 1px solid #e2e8f0; border-bottom: 1px solid #e2e8f0; background: white; color: #4a5568; font-size: 0.9rem; transition: background-color 0.2s ease; }
+        .level-header { background: #e2e8f0; padding: 12px; font-weight: 600; text-align: center; border-bottom: 1px solid #cbd5e0; color: var(--color-gray-text); font-size: 0.9rem; }
+        .level-content { padding: 20px; border-right: 1px solid var(--color-gray-border-medium); border-bottom: 1px solid var(--color-gray-border-medium); background: var(--color-white); color: var(--color-gray-text); font-size: 0.9rem; transition: background-color 0.2s; }
         .level-content:last-child { border-right: none; }
-        .row-label { background: #64748b; padding: 20px; font-weight: 600; color: white; border-bottom: 1px solid #e2e8f0; display: flex; align-items: center; font-size: 0.9rem; }
+        .row-label { background: #64748b; padding: 20px; font-weight: 600; color: white; border-bottom: 1px solid var(--color-gray-border-medium); display: flex; align-items: center; font-size: 0.9rem; }
+
+        /* Look-fors (Best Practices) */
+        .look-fors-section { border-top: 1px solid var(--color-gray-border-medium); }
+        .look-fors-header { background: linear-gradient(135deg, #3182ce, #2b77cb); color: white; padding: 10px 20px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-weight: 600; transition: background 0.3s ease; font-size: 0.85rem; }
+        .look-fors-header:hover { background: linear-gradient(135deg, #2b77cb, #2c5aa0); }
+        .chevron { transition: transform 0.3s ease; font-size: 1rem; }
+        .chevron.expanded { transform: rotate(180deg); }
+        .look-fors-content { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; background: var(--color-gray-bg-light); }
+        .look-fors-content.expanded { max-height: 250px; }
+        .look-fors-grid { padding: 12px 20px; display: grid; grid-template-columns: 1fr; gap: 8px; }
+        .look-for-item { display: flex; align-items: flex-start; gap: 8px; padding: 8px 12px; background: var(--color-white); border-radius: 4px; box-shadow: 0 1px 2px rgba(0,0,0,0.08); border-left: 3px solid var(--color-blue-base); }
+        .look-for-item label { cursor: pointer; color: var(--color-gray-text); font-weight: 500; font-size: 0.85rem; line-height: 1.4; }
+
+        /* Component Assignment & Highlighting */
+        .component-section.component-assigned { border-left: 4px solid var(--color-green-base); background: var(--color-green-light-bg); }
+        .component-section.component-not-assigned { border-left: 4px solid var(--color-gray-component-not-assigned-border); }
+        .component-section.component-not-assigned .level-content { color: var(--color-text-deemphasized); }
+        .component-section[data-assigned="true"]:hover { border-left-color: var(--color-green-dark); }
+        .component-section:not([data-assigned="true"]):hover { border-left-color: var(--color-gray-border-light); background-color: var(--color-gray-bg-light); }
+        .component-hidden { display: none; }
         
-        /* Interactive styles */
+        /* Interactive Rubric Styles */
         .level-content.editable { cursor: pointer; }
-        .level-content.editable:hover { background-color: #eff6ff; }
-        .level-content.selected { background-color: #bfdbfe !important; border: 2px solid #3b82f6; font-weight: 600; color: #1e40af; }
+        .level-content.editable:hover { background-color: var(--color-blue-light-bg); }
+        .level-content.selected { background-color: var(--color-blue-light-bg) !important; border: 2px solid var(--color-blue-base); font-weight: 600; color: var(--color-blue-text-dark); }
 
         /* Media Upload Styles */
-        .media-upload-section { padding: 15px 20px; background-color: #f7fafc; border-top: 1px solid #e2e8f0; }
-        .media-upload-title { font-weight: 600; color: #4a5568; margin-bottom: 10px; font-size: 0.9rem; }
+        .media-upload-section { padding: 15px 20px; background-color: var(--color-gray-bg-light); border-top: 1px solid var(--color-gray-border-medium); }
+        .media-upload-title { font-weight: 600; color: var(--color-gray-text); margin-bottom: 10px; font-size: 0.9rem; }
         .media-upload-area { display: flex; gap: 10px; align-items: center; }
         .media-upload-input { display: none; }
-        .media-upload-label { background: #6b7280; color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; font-size: 0.85rem; transition: background-color 0.2s; }
-        .media-upload-label:hover { background: #4b5563; }
-        .upload-status { font-size: 0.85rem; color: #4a5568; font-style: italic; }
+        .media-upload-label { background: var(--color-gray-bg-medium); color: white; padding: 8px 16px; border-radius: 6px; cursor: pointer; font-size: 0.85rem; transition: background-color 0.2s; }
+        .media-upload-label:hover { background: var(--color-gray-bg-dark); }
+        .upload-status { font-size: 0.85rem; color: var(--color-gray-text); font-style: italic; }
         .evidence-list { margin-top: 10px; padding-left: 20px; }
         .evidence-item { margin-bottom: 5px; font-size: 0.9rem; }
-        .evidence-item a { color: #3b82f6; text-decoration: none; } .evidence-item a:hover { text-decoration: underline; }
+        .evidence-item a { color: var(--color-blue-base); text-decoration: none; }
+        .evidence-item a:hover { text-decoration: underline; }
 
         /* View Toggle Button */
         .view-toggle-button {
-            background-color: #e9ecef;
-            border: 1px solid #ced4da;
+            background-color: var(--color-gray-bg-light);
+            border: 1px solid var(--color-gray-border-light);
             padding: 8px 16px;
             margin: 0 0 20px 0;
             border-radius: 6px;
             cursor: pointer;
             font-weight: 500;
-            color: #495057;
+            color: var(--color-gray-text);
             transition: all 0.2s ease;
         }
-        .view-toggle-button:hover {
-            background-color: #dee2e6;
-            border-color: #adb5bd;
+        .view-toggle-button:hover { background-color: #dee2e6; border-color: #adb5bd; }
+        .filter-status {
+            background: var(--color-blue-light-bg);
+            border: 1px solid var(--color-blue-base);
+            border-radius: 8px;
+            padding: 15px;
+            margin-bottom: 20px;
+            color: var(--color-blue-text-dark);
+            font-weight: 500;
+            display: none;
         }
-        
-        /* Assignment Highlighting */
-        .component-assigned { border-left: 4px solid #10b981; }
-        .component-not-assigned { border-left: 4px solid #e5e7eb; }
+
+        /* Responsive Styles */
+        @media (max-width: 768px) {
+            .content { padding: 20px; }
+            .actions-grid { grid-template-columns: 1fr; }
+            .filter-row { flex-direction: column; align-items: stretch; }
+            .filter-select, .filter-btn { min-width: auto; width: 100%; }
+            .performance-levels, .performance-levels-content { grid-template-columns: 1fr; gap: 1px; }
+            .level-header, .row-label, .level-content { border-right: none; padding: 15px; font-size: 0.9rem; }
+        }
     </style>
 </head>
 <body>
@@ -447,6 +381,44 @@
         function handleDeleteObservation(obsId, email, name) { if (confirm('Are you sure you want to delete this draft? This cannot be undone.')) { showLoading('Deleting draft...'); google.script.run.withSuccessHandler(res => { if(res.success) { displayObservationOptions(email, name); } else { showError(res.error); } }).withFailureHandler(handleError).deleteObservation(obsId); } }
         function handleFinalizeObservation(obsId, email, name) { if (confirm('Are you sure you want to finalize this observation? You will not be able to edit it further.')) { showLoading('Finalizing...'); google.script.run.withSuccessHandler(res => { if(res.success) { displayObservationOptions(email, name); } else { showError(res.error); } }).withFailureHandler(handleError).finalizeObservation(obsId); } }
 
+        function toggleLookFors(componentId) {
+            const content = document.getElementById(`lookForsContent-${componentId}`);
+            const chevron = document.getElementById(`chevron-${componentId}`);
+
+            if (content && chevron) {
+                const isExpanded = content.classList.toggle('expanded');
+                chevron.classList.toggle('expanded');
+                try {
+                    const storageKey = `lookFors_${componentId}_${window.pageLoadInfo.cacheVersion}`;
+                    sessionStorage.setItem(storageKey, isExpanded);
+                } catch (e) {
+                    console.warn('SessionStorage not available for look-fors state.');
+                }
+            }
+        }
+
+        function restoreLookForsState() {
+            try {
+                if (!window.pageLoadInfo) return;
+                for (let i = 0; i < sessionStorage.length; i++) {
+                    const key = sessionStorage.key(i);
+                    if (key && key.startsWith('lookFors_') && key.endsWith(window.pageLoadInfo.cacheVersion)) {
+                        if (sessionStorage.getItem(key) === 'true') {
+                            const componentId = key.replace('lookFors_', '').replace(`_${window.pageLoadInfo.cacheVersion}`, '');
+                            const content = document.getElementById(`lookForsContent-${componentId}`);
+                            const chevron = document.getElementById(`chevron-${componentId}`);
+                            if (content && chevron) {
+                                content.classList.add('expanded');
+                                chevron.classList.add('expanded');
+                            }
+                        }
+                    }
+                }
+            } catch (e) {
+                console.warn('Could not restore look-fors state:', e);
+            }
+        }
+
         function handleRubricData(result) {
             hideLoading();
             if (!result.success) return showError(result.error);
@@ -455,6 +427,10 @@
             const { observation, rubricData } = result;
             currentObservationId = observation ? observation.observationId : null;
             observationViewMode = (rubricData.userContext && rubricData.userContext.viewMode) || 'assigned';
+
+            window.pageLoadInfo = {
+                cacheVersion: rubricData.userContext ? rubricData.userContext.cacheVersion : 'unknown'
+            };
             
             updateFilterStatus(rubricData, observation);
             const rubricHtml = generateInteractiveRubricHtml(rubricData, observation);
@@ -463,6 +439,7 @@
             if (rubricData.userContext.isEvaluator) {
                 updateComponentVisibility();
             }
+            restoreLookForsState();
             showView('rubricContainer');
         }
 
@@ -474,10 +451,10 @@
             html += `<button class="filter-btn btn-secondary" onclick="showView('observationSelectorView')">Back to Observations</button>`;
             html += `</div>`;
 
-            data.domains.forEach(domain => {
-                html += `<div class="domain-section"><div class="domain-header">${domain.name}</div>`;
+            data.domains.forEach((domain, domainIdx) => {
+                html += `<div class="domain-section" id="domain-${domainIdx}"><div class="domain-header">${domain.name}</div>`;
                 html += `<div class="performance-levels-header"><div class="performance-levels"><div class="level-header"></div><div class="level-header">Developing</div><div class="level-header">Basic</div><div class="level-header">Proficient</div><div class="level-header">Distinguished</div></div></div>`;
-                domain.components.forEach(comp => {
+                domain.components.forEach((comp, compIdx) => {
                     const componentId = comp.componentId;
                     const isAssigned = comp.isAssigned || false;
                     const selectedProficiency = observation?.observationData?.[componentId];
@@ -490,6 +467,24 @@
                         html += `<div class="level-content ${isEvaluator ? 'editable' : ''} ${isSelected ? 'selected' : ''}" data-level="${level}" onclick="${isEvaluator ? `selectProficiency(this, '${componentId}', '${level}')` : ''}">${comp[level] || ''}</div>`;
                     });
                     html += `</div>`;
+
+                    if (comp.bestPractices && comp.bestPractices.length > 0) {
+                        const lookForsId = `domain-${domainIdx}-component-${compIdx}`;
+                        html += `<div class="look-fors-section">`;
+                        html += `<div class="look-fors-header" onclick="toggleLookFors('${lookForsId}')">`;
+                        html += `<span>Best Practices aligned with 5D+ and PELSB Standards</span>`;
+                        html += `<span class="chevron" id="chevron-${lookForsId}">▼</span>`;
+                        html += `</div>`;
+                        html += `<div class="look-fors-content" id="lookForsContent-${lookForsId}">`;
+                        html += `<div class="look-fors-grid">`;
+                        comp.bestPractices.forEach((practice, practiceIdx) => {
+                            const practiceId = `practice-${domainIdx}-${compIdx}-${practiceIdx}`;
+                            html += `<div class="look-for-item">`;
+                            html += `<input type="checkbox" id="${practiceId}" name="${practiceId}"><label for="${practiceId}">${practice}</label>`;
+                            html += `</div>`;
+                        });
+                        html += `</div></div></div>`;
+                    }
                     
                     if (isEvaluator) {
                         let evidenceHtml = '';

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -40,6 +40,10 @@
     --color-gray-component-not-assigned-border: #e5e7eb;
     --color-gray-assignment-indicator-not-assigned-bg: #e5e7eb;
     --color-text-deemphasized: #718096;
+
+    /* Reds for destructive actions */
+    --color-red-base: #dc2626;
+    --color-red-dark: #b91c1c;
 }
 
         * {
@@ -120,7 +124,7 @@
             box-shadow: 0 8px 25px rgba(0,0,0,0.1);
         }
         .action-icon { font-size: 2.5rem; margin-bottom: 15px; display: block; }
-        .action-title { font-weight: 600; color: #2d3748; font-size: 1.1rem; margin-bottom: 8px; }
+        .action-title { font-weight: 600; color: var(--color-gray-text-light); font-size: 1.1rem; margin-bottom: 8px; }
         .action-desc { color: var(--color-text-deemphasized); font-size: 0.95rem; }
 
         /* Filter controls */
@@ -184,19 +188,19 @@
         }
         .observation-card:hover { box-shadow: 0 8px 25px rgba(0,0,0,0.08); transform: translateY(-2px); }
         .obs-card-content { padding: 20px; flex-grow: 1; }
-        .obs-card-title { font-weight: 600; color: #2d3748; font-size: 1.1rem; margin-bottom: 4px; }
+        .obs-card-title { font-weight: 600; color: var(--color-gray-text-light); font-size: 1.1rem; margin-bottom: 4px; }
         .obs-card-desc { color: var(--color-text-deemphasized); font-size: 0.9rem; margin-bottom: 12px; }
         .status-badge { display: inline-block; padding: 4px 10px; font-size: 0.8rem; font-weight: 600; border-radius: 9999px; }
         .status-draft { background-color: var(--color-amber-light-bg); color: var(--color-amber-text-dark); }
-        .status-finalized { background-color: var(--color-green-light-bg); color: #166534; }
+        .status-finalized { background-color: var(--color-green-light-bg); color: var(--color-green-darker); }
         .obs-card-actions { background: var(--color-gray-bg-light); border-top: 1px solid var(--color-gray-border-medium); padding: 15px 20px; display: flex; gap: 10px; justify-content: flex-end; }
         .obs-card-actions .filter-btn { padding: 8px 16px; font-size: 0.9rem; min-width: auto; }
         .btn-edit { background: #3b82f6; border-color: #3b82f6; }
         .btn-edit:hover { background: #2563eb; border-color: #2563eb; }
         .btn-finalize { background: var(--color-green-base); border-color: var(--color-green-base); }
         .btn-finalize:hover { background: var(--color-green-dark); border-color: var(--color-green-dark); }
-        .btn-delete { background: #dc2626; border-color: #dc2626; }
-        .btn-delete:hover { background: #b91c1c; border-color: #b91c1c; }
+        .btn-delete { background: var(--color-red-base); border-color: var(--color-red-base); }
+        .btn-delete:hover { background: var(--color-red-dark); border-color: var(--color-red-dark); }
 
         /* === Rubric Styles (from rubric.html) === */
         .rubric-container { display: none; margin-top: 30px; }
@@ -218,7 +222,7 @@
         .chevron { transition: transform 0.3s ease; font-size: 1rem; }
         .chevron.expanded { transform: rotate(180deg); }
         .look-fors-content { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; background: var(--color-gray-bg-light); }
-        .look-fors-content.expanded { max-height: 250px; }
+        .look-fors-content.expanded { max-height: 1000px; }
         .look-fors-grid { padding: 12px 20px; display: grid; grid-template-columns: 1fr; gap: 8px; }
         .look-for-item { display: flex; align-items: flex-start; gap: 8px; padding: 8px 12px; background: var(--color-white); border-radius: 4px; box-shadow: 0 1px 2px rgba(0,0,0,0.08); border-left: 3px solid var(--color-blue-base); }
         .look-for-item label { cursor: pointer; color: var(--color-gray-text); font-weight: 500; font-size: 0.85rem; line-height: 1.4; }
@@ -389,8 +393,10 @@
                 const isExpanded = content.classList.toggle('expanded');
                 chevron.classList.toggle('expanded');
                 try {
-                    const storageKey = `lookFors_${componentId}_${window.pageLoadInfo.cacheVersion}`;
-                    sessionStorage.setItem(storageKey, isExpanded);
+                    const storageKey = `lookForsState_${window.pageLoadInfo.cacheVersion}`;
+                    const allStates = JSON.parse(sessionStorage.getItem(storageKey) || '{}');
+                    allStates[componentId] = isExpanded;
+                    sessionStorage.setItem(storageKey, JSON.stringify(allStates));
                 } catch (e) {
                     console.warn('SessionStorage not available for look-fors state.');
                 }
@@ -400,17 +406,16 @@
         function restoreLookForsState() {
             try {
                 if (!window.pageLoadInfo) return;
-                for (let i = 0; i < sessionStorage.length; i++) {
-                    const key = sessionStorage.key(i);
-                    if (key && key.startsWith('lookFors_') && key.endsWith(window.pageLoadInfo.cacheVersion)) {
-                        if (sessionStorage.getItem(key) === 'true') {
-                            const componentId = key.replace('lookFors_', '').replace(`_${window.pageLoadInfo.cacheVersion}`, '');
-                            const content = document.getElementById(`lookForsContent-${componentId}`);
-                            const chevron = document.getElementById(`chevron-${componentId}`);
-                            if (content && chevron) {
-                                content.classList.add('expanded');
-                                chevron.classList.add('expanded');
-                            }
+                const storageKey = `lookForsState_${window.pageLoadInfo.cacheVersion}`;
+                const allStates = JSON.parse(sessionStorage.getItem(storageKey) || '{}');
+
+                for (const componentId in allStates) {
+                    if (allStates[componentId] === true) {
+                        const content = document.getElementById(`lookForsContent-${componentId}`);
+                        const chevron = document.getElementById(`chevron-${componentId}`);
+                        if (content && chevron) {
+                            content.classList.add('expanded');
+                            chevron.classList.add('expanded');
                         }
                     }
                 }
@@ -479,8 +484,11 @@
                         html += `<div class="look-fors-grid">`;
                         comp.bestPractices.forEach((practice, practiceIdx) => {
                             const practiceId = `practice-${domainIdx}-${compIdx}-${practiceIdx}`;
+                            const tempEl = document.createElement('span');
+                            tempEl.textContent = practice;
+                            const sanitizedPractice = tempEl.innerHTML;
                             html += `<div class="look-for-item">`;
-                            html += `<input type="checkbox" id="${practiceId}" name="${practiceId}"><label for="${practiceId}">${practice}</label>`;
+                            html += `<input type="checkbox" id="${practiceId}" name="${practiceId}"><label for="${practiceId}">${sanitizedPractice}</label>`;
                             html += `</div>`;
                         });
                         html += `</div></div></div>`;

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -393,6 +393,7 @@
                 const isExpanded = content.classList.toggle('expanded');
                 chevron.classList.toggle('expanded');
                 try {
+                    if (!window.pageLoadInfo) return;
                     const storageKey = `lookForsState_${window.pageLoadInfo.cacheVersion}`;
                     const allStates = JSON.parse(sessionStorage.getItem(storageKey) || '{}');
                     allStates[componentId] = isExpanded;

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -485,9 +485,7 @@
                         html += `<div class="look-fors-grid">`;
                         comp.bestPractices.forEach((practice, practiceIdx) => {
                             const practiceId = `practice-${domainIdx}-${compIdx}-${practiceIdx}`;
-                            const tempEl = document.createElement('span');
-                            tempEl.textContent = practice;
-                            const sanitizedPractice = tempEl.innerHTML;
+                            const sanitizedPractice = escapeHtml(practice);
                             html += `<div class="look-for-item">`;
                             html += `<input type="checkbox" id="${practiceId}" name="${practiceId}"><label for="${practiceId}">${sanitizedPractice}</label>`;
                             html += `</div>`;


### PR DESCRIPTION
This commit brings the styling and features of the peer evaluator's observation view in `filter-interface.html` in line with the main rubric in `rubric.html`, providing you with a more professional and consistent experience.

Key changes:
- Consolidated CSS styles from `rubric.html` into `filter-interface.html`, introducing CSS variables for a consistent color scheme and applying the more polished rubric design to the observation view.
- Enhanced the dynamically generated rubric in the observation view to include the "Best Practices" (look-fors) section, which was previously missing.
- Implemented expand/collapse interactivity for the "Best Practices" section, with its state saved to sessionStorage to persist during your session.