### PR TITLE
I've finished adding the new options for managing finalized observati…

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -423,11 +423,13 @@ function exportObservationToPdf(observationId) {
         let obsFolderIterator = userFolder.getFoldersByName(obsFolderName);
         let obsFolder = obsFolderIterator.hasNext() ? obsFolderIterator.next() : userFolder.createFolder(obsFolderName);
 
-        const docFile = DriveApp.getFileById(doc.getId());
+        const docFile = DriveApp.getFileById(docId);
         const pdfBlob = docFile.getAs('application/pdf');
         const pdfFile = obsFolder.createFile(pdfBlob).setName(docName + ".pdf");
 
-        DriveApp.getFileById(doc.getId()).setTrashed(true);
+        // Move the temporary Google Doc to trash after PDF creation.
+        // We trash (not permanently delete) to allow for recovery in case of errors or audit needs.
+        DriveApp.getFileById(docId).setTrashed(true);
 
         return { success: true, pdfUrl: pdfFile.getUrl() };
 

--- a/Code.js
+++ b/Code.js
@@ -370,7 +370,7 @@ function exportObservationToPdf(observationId) {
             return { success: false, error: `Failed to load rubric data: ${rubricData.errorMessage}` };
         }
 
-        const docName = `Observation for ${observation.observedName} - ${new Date(observation.finalizedAt || Date.now()).toLocaleDateString()}`;
+        const docName = `Observation for ${observation.observedName} - ${new Date(observation.finalizedAt || Date.now()).toISOString().slice(0, 10)}`;
         const doc = DocumentApp.create(docName);
         const body = doc.getBody();
 

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -201,6 +201,10 @@
         .btn-finalize:hover { background: var(--color-green-dark); border-color: var(--color-green-dark); }
         .btn-delete { background: var(--color-red-base); border-color: var(--color-red-base); }
         .btn-delete:hover { background: var(--color-red-dark); border-color: var(--color-red-dark); }
+        .btn-view { background: #3b82f6; border-color: #3b82f6; }
+        .btn-view:hover { background: #2563eb; border-color: #2563eb; }
+        .btn-export { background: var(--color-green-base); border-color: var(--color-green-base); }
+        .btn-export:hover { background: var(--color-green-dark); border-color: var(--color-green-dark); }
 
         /* === Rubric Styles (from rubric.html) === */
         .rubric-container { display: none; margin-top: 30px; }
@@ -381,10 +385,16 @@
                 let cardsHtml = `<div class="action-card" onclick="handleNewObservation('${observedEmail}')"><span class="action-icon">➕</span><div class="action-title">Start New Observation</div><div class="action-desc">Begin a new evaluation for this staff member.</div></div>`;
                 result.observations.forEach(obs => {
                     const date = new Date(obs.createdAt).toLocaleDateString();
-                    const buttons = obs.status === 'Draft' ?
-                        `<button class="filter-btn btn-edit" onclick="handleEditObservation('${obs.observationId}')">Edit</button>
-                         <button class="filter-btn btn-finalize" onclick="handleFinalizeObservation('${obs.observationId}', '${observedEmail}', '${observedName}')">Finalize</button>
-                         <button class="filter-btn btn-delete" onclick="handleDeleteObservation('${obs.observationId}', '${observedEmail}', '${observedName}')">Delete</button>` : '';
+                    let buttons = '';
+                    if (obs.status === 'Draft') {
+                        buttons = `<button class="filter-btn btn-edit" onclick="handleEditObservation('${obs.observationId}')">Edit</button>
+                                   <button class="filter-btn btn-finalize" onclick="handleFinalizeObservation('${obs.observationId}', '${observedEmail}', '${observedName}')">Finalize</button>
+                                   <button class="filter-btn btn-delete" onclick="handleDeleteObservation('${obs.observationId}', '${observedEmail}', '${observedName}')">Delete</button>`;
+                    } else if (obs.status === 'Finalized') {
+                        buttons = `<button class="filter-btn btn-view" onclick="handleViewObservation('${obs.observationId}')">View</button>
+                                   <button class="filter-btn btn-export" onclick="handleExportToPdf('${obs.observationId}')">Export to PDF</button>
+                                   <button class="filter-btn btn-delete" onclick="handleDeleteFinalizedObservation('${obs.observationId}', '${observedEmail}', '${observedName}')">Delete</button>`;
+                    }
                     cardsHtml += `
                         <div class="observation-card">
                             <div class="obs-card-content">
@@ -403,6 +413,36 @@
         function handleEditObservation(obsId) { showLoading('Loading observation...'); google.script.run.withSuccessHandler(handleRubricData).withFailureHandler(handleError).loadObservationForEditing(obsId); }
         function handleDeleteObservation(obsId, email, name) { if (confirm('Are you sure you want to delete this draft? This cannot be undone.')) { showLoading('Deleting draft...'); google.script.run.withSuccessHandler(res => { if(res.success) { displayObservationOptions(email, name); } else { showError(res.error); } }).withFailureHandler(handleError).deleteObservation(obsId); } }
         function handleFinalizeObservation(obsId, email, name) { if (confirm('Are you sure you want to finalize this observation? You will not be able to edit it further.')) { showLoading('Finalizing...'); google.script.run.withSuccessHandler(res => { if(res.success) { displayObservationOptions(email, name); } else { showError(res.error); } }).withFailureHandler(handleError).finalizeObservation(obsId); } }
+
+        function handleViewObservation(obsId) {
+            showLoading('Loading observation...');
+            google.script.run.withSuccessHandler(handleRubricData).withFailureHandler(handleError).loadFinalizedObservationForViewing(obsId);
+        }
+
+        function handleDeleteFinalizedObservation(obsId, email, name) {
+            if (confirm('Are you sure you want to PERMANENTLY DELETE this finalized observation? This action cannot be undone.')) {
+                showLoading('Deleting observation...');
+                google.script.run.withSuccessHandler(res => {
+                    if(res.success) {
+                        displayObservationOptions(email, name);
+                    } else {
+                        showError(res.error);
+                    }
+                }).withFailureHandler(handleError).deleteFinalizedObservation(obsId);
+            }
+        }
+
+        function handleExportToPdf(obsId) {
+            showLoading('Generating PDF...');
+            google.script.run.withSuccessHandler(res => {
+                hideLoading();
+                if (res.success) {
+                    window.open(res.pdfUrl, '_blank');
+                } else {
+                    showError(res.error);
+                }
+            }).withFailureHandler(handleError).exportObservationToPdf(obsId);
+        }
 
         function toggleLookFors(componentId) {
             const content = document.getElementById(`lookForsContent-${componentId}`);
@@ -528,9 +568,20 @@
         function updateFilterStatus(rubricData, observation) {
             const status = document.getElementById('filterStatus'); const statusText = document.getElementById('filterStatusText');
             let text = 'Viewing Your Own Rubric';
-            if (rubricData?.userContext?.filterInfo) { text = `Viewing as: ${rubricData.userContext.filterInfo.viewingAs} (${rubricData.userContext.filterInfo.viewingRole}, Year ${rubricData.userContext.filterInfo.viewingYear})`; }
-            if (observation) { text = `Observing: ${observation.observedName} &mdash; <strong>Observation Draft</strong>`; }
-            statusText.innerHTML = text; status.style.display = 'block';
+            if (rubricData?.userContext?.filterInfo) {
+                text = `Viewing as: ${rubricData.userContext.filterInfo.viewingAs} (${rubricData.userContext.filterInfo.viewingRole}, Year ${rubricData.userContext.filterInfo.viewingYear})`;
+            }
+            if (observation) {
+                let statusLabel = `<strong>Observation ${observation.status}</strong>`;
+                if (observation.status === 'Draft') {
+                    statusLabel = `<strong>Observation Draft</strong>`;
+                } else if (observation.status === 'Finalized') {
+                    statusLabel = `<strong>Finalized Observation (Read-Only)</strong>`;
+                }
+                text = `Observing: ${observation.observedName} &mdash; ${statusLabel}`;
+            }
+            statusText.innerHTML = text;
+            status.style.display = 'block';
         }
 
         function selectProficiency(element, componentId, proficiency) {


### PR DESCRIPTION
…ons.

On the finalized observation cards, you will now see the following options:
- **View:** Opens the observation in a read-only mode.
- **Delete:** Permanently deletes the finalized observation and its associated Google Drive folder.
- **Export to PDF:** Generates a well-formatted PDF of the observation report and saves it to the observation's Google Drive folder.

To make this work, I updated `filter-interface.html` on the frontend to display the new buttons. I also added the necessary backend logic to `Code.js` and `ObservationService.js` to handle these new actions, which includes the PDF generation and Google Drive integration.