### PR TITLE
feat: Add visual PDF export for rubrics

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -364,6 +364,7 @@ function exportObservationToPdf(observationId) {
         }
 
         const assignedSubdomains = getAssignedSubdomainsForRoleYear(observation.observedRole, observation.observedYear);
+        // We need 'full' view to get all component data, the template will filter based on observation data
         const rubricData = getAllDomainsData(observation.observedRole, observation.observedYear, 'full', assignedSubdomains);
 
         if (rubricData.isError) {
@@ -371,132 +372,18 @@ function exportObservationToPdf(observationId) {
         }
 
         const docName = `Observation for ${observation.observedName} - ${new Date(observation.finalizedAt || Date.now()).toISOString().slice(0, 10)}`;
-        const doc = DocumentApp.create(docName);
-        const body = doc.getBody();
 
-        const styles = {
-            HEADING1: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 18,
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.HORIZONTAL_ALIGNMENT]: DocumentApp.HorizontalAlignment.CENTER,
-                [DocumentApp.Attribute.SPACING_AFTER]: 20
-            },
-            HEADING2: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 14,
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.FOREGROUND_COLOR]: '#4a5568',
-                [DocumentApp.Attribute.SPACING_BEFORE]: 20,
-                [DocumentApp.Attribute.SPACING_AFTER]: 10
-            },
-            HEADING3: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 12,
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.ITALIC]: true,
-                [DocumentApp.Attribute.FOREGROUND_COLOR]: '#2d3748',
-                [DocumentApp.Attribute.SPACING_BEFORE]: 15,
-                [DocumentApp.Attribute.SPACING_AFTER]: 5
-            },
-            PROFICIENCY: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 11,
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.FOREGROUND_COLOR]: '#3182ce'
-            },
-            DESCRIPTION: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 10,
-                [DocumentApp.Attribute.SPACING_AFTER]: 10
-            },
-            EVIDENCE_HEADING: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 11,
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.SPACING_BEFORE]: 10
-            },
-            EVIDENCE_ITEM: {
-                [DocumentApp.Attribute.FONT_FAMILY]: 'Arial',
-                [DocumentApp.Attribute.FONT_SIZE]: 10
-            },
-            TABLE: {
-                [DocumentApp.Attribute.BORDER_WIDTH]: 1,
-                [DocumentApp.Attribute.BORDER_COLOR]: '#e2e8f0'
-            },
-            TABLE_HEADER_CELL: {
-                [DocumentApp.Attribute.BACKGROUND_COLOR]: '#e2e8f0',
-                [DocumentApp.Attribute.BOLD]: true,
-                [DocumentApp.Attribute.FONT_SIZE]: 10,
-                [DocumentApp.Attribute.FOREGROUND_COLOR]: '#4a5568'
-            },
-            TABLE_CELL: {
-                [DocumentApp.Attribute.FONT_SIZE]: 10,
-                [DocumentApp.Attribute.PADDING_TOP]: 5,
-                [DocumentApp.Attribute.PADDING_BOTTOM]: 5,
-                [DocumentApp.Attribute.PADDING_LEFT]: 5,
-                [DocumentApp.Attribute.PADDING_RIGHT]: 5
-            },
-            CENTERED_INFO: {
-                [DocumentApp.Attribute.HORIZONTAL_ALIGNMENT]: DocumentApp.HorizontalAlignment.CENTER
-            }
+        // Create HTML content from template
+        const template = HtmlService.createTemplateFromFile('pdf-rubric.html');
+        template.data = {
+            observation: observation,
+            rubricData: rubricData
         };
+        const htmlContent = template.evaluate().getContent();
 
-        body.setAttributes({ [DocumentApp.Attribute.FONT_FAMILY]: 'Arial', [DocumentApp.Attribute.FONT_SIZE]: 11 });
+        // Create PDF from HTML
+        const pdfBlob = Utilities.newBlob(htmlContent, 'text/html', docName + '.html').getAs('application/pdf');
 
-        const heading1 = body.appendParagraph('Observation Report');
-        heading1.setAttributes(styles.HEADING1);
-
-        const observedNamePara = body.appendParagraph(`${observation.observedName}`);
-        observedNamePara.setAttributes(styles.HEADING1);
-        observedNamePara.setBold(true);
-
-        body.appendParagraph(`Role: ${observation.observedRole} | Year: ${observation.observedYear || 'N/A'}`).setAttributes(styles.CENTERED_INFO);
-        body.appendParagraph(`Observer: ${observation.observerEmail}`).setAttributes(styles.CENTERED_INFO);
-        const finalizedDate = observation.finalizedAt ? new Date(observation.finalizedAt).toLocaleString() : 'N/A';
-        body.appendParagraph(`Finalized on: ${finalizedDate}`).setAttributes(styles.CENTERED_INFO);
-        body.appendHorizontalRule();
-
-        rubricData.domains.forEach(domain => {
-            if (domain.components.some(c => observation.observationData[c.componentId])) {
-                const domainPara = body.appendParagraph(domain.name);
-                domainPara.setAttributes(styles.HEADING2);
-
-                domain.components.forEach(component => {
-                    const proficiency = observation.observationData[component.componentId];
-                    if (proficiency) {
-                        const componentPara = body.appendParagraph(component.title);
-                        componentPara.setAttributes(styles.HEADING3);
-
-                        const proficiencyPara = body.appendParagraph(`Selected Proficiency: ${proficiency.charAt(0).toUpperCase() + proficiency.slice(1)}`);
-                        proficiencyPara.setAttributes(styles.PROFICIENCY);
-
-                        const description = component[proficiency];
-                        if (description) {
-                            body.appendParagraph(description).setAttributes(styles.DESCRIPTION);
-                        }
-                        const evidence = observation.evidenceLinks[component.componentId];
-                        if (evidence && evidence.length > 0) {
-                            body.appendParagraph("Evidence:").setAttributes(styles.EVIDENCE_HEADING);
-                            evidence.forEach(item => {
-                                const li = body.appendListItem('');
-                                li.setGlyphType(DocumentApp.GlyphType.SQUARE_BULLET);
-                                li.setText(`${item.name}: `);
-                                const link = li.appendText(item.url);
-                                link.setLinkUrl(item.url);
-                                link.setAttributes(styles.EVIDENCE_ITEM);
-                            });
-                        }
-                        body.appendParagraph("");
-                    }
-                });
-            }
-        });
-
-        doc.saveAndClose();
-
-        // Get the document ID after saving and closing.
-        const docId = doc.getId();
         // Find or create the folder structure in Google Drive.
         const rootFolderIterator = DriveApp.getFoldersByName(DRIVE_FOLDER_INFO.ROOT_FOLDER_NAME);
         let rootFolder = rootFolderIterator.hasNext() ? rootFolderIterator.next() : DriveApp.createFolder(DRIVE_FOLDER_INFO.ROOT_FOLDER_NAME);
@@ -507,13 +394,7 @@ function exportObservationToPdf(observationId) {
         let obsFolderIterator = userFolder.getFoldersByName(obsFolderName);
         let obsFolder = obsFolderIterator.hasNext() ? obsFolderIterator.next() : userFolder.createFolder(obsFolderName);
 
-        // Create the PDF from the document.
-        const docFile = DriveApp.getFileById(docId);
-        const pdfBlob = docFile.getAs('application/pdf');
         const pdfFile = obsFolder.createFile(pdfBlob).setName(docName + ".pdf");
-
-        // Move the temporary Google Doc to trash (rather than permanently deleting) to allow for recovery and audit purposes.
-        DriveApp.getFileById(docId).setTrashed(true);
 
         return { success: true, pdfUrl: pdfFile.getUrl() };
 

--- a/pdf-rubric.html
+++ b/pdf-rubric.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Observation Report</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background-color: #fff;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .header {
+            text-align: center;
+            padding-bottom: 20px;
+            border-bottom: 2px solid #e2e8f0;
+        }
+        .header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 10px;
+        }
+        .header p {
+            font-size: 0.9rem;
+            opacity: 0.9;
+        }
+        .domain-section {
+            border-bottom: 3px solid #e2e8f0;
+            margin-top: 20px;
+            page-break-inside: avoid;
+        }
+        .domain-header {
+            background: linear-gradient(135deg, #7c9ac5, #5a82b8);
+            color: white;
+            padding: 15px 20px;
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+        .performance-levels-header {
+            border-bottom: 2px solid #e2e8f0;
+        }
+        .performance-levels {
+            display: grid;
+            grid-template-columns: 200px 1fr 1fr 1fr 1fr;
+        }
+        .performance-levels-content {
+            display: grid;
+            grid-template-columns: 200px 1fr 1fr 1fr 1fr;
+        }
+        .level-header {
+            background: #e2e8f0;
+            padding: 12px;
+            font-weight: 600;
+            text-align: center;
+            border-bottom: 1px solid #cbd5e0;
+            color: #4a5568;
+            font-size: 0.9rem;
+        }
+        .level-content {
+            padding: 20px;
+            border-right: 1px solid #e2e8f0;
+            border-bottom: 1px solid #e2e8f0;
+            background: white;
+            color: #4a5568;
+            font-size: 0.9rem;
+        }
+        .level-content.selected {
+            background-color: #dbeafe;
+            border-color: #3b82f6;
+            color: #1e40af;
+            font-weight: 600;
+            border-left: 3px solid #3b82f6;
+        }
+        .row-label {
+            background: #64748b;
+            padding: 20px;
+            font-weight: 600;
+            color: white;
+            border-bottom: 1px solid #e2e8f0;
+            display: flex;
+            align-items: center;
+            font-size: 0.9rem;
+        }
+        .media-links-container {
+            padding: 10px 20px;
+            background: #f8fafc;
+            border-top: 1px solid #e2e8f0;
+        }
+        .media-link-item a {
+            color: #3182ce;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Observation Report for <?= data.observation.observedName ?></h1>
+            <p>Role: <?= data.observation.observedRole ?> | Year: <?= data.observation.observedYear || 'N/A' ?></p>
+            <p>Observer: <?= data.observation.observerEmail ?></p>
+            <p>Finalized on: <?= new Date(data.observation.finalizedAt).toLocaleString() ?></p>
+        </div>
+
+        <? for (var domainIdx = 0; domainIdx < data.rubricData.domains.length; domainIdx++) {
+            var domain = data.rubricData.domains[domainIdx];
+            var domainHasContent = domain.components.some(c => data.observation.observationData[c.componentId]);
+        ?>
+            <? if (domainHasContent) { ?>
+            <div class="domain-section">
+                <div class="domain-header">
+                    <?= domain.name ?>
+                </div>
+
+                <div class="performance-levels-header">
+                    <div class="performance-levels">
+                        <div class="level-header"></div>
+                        <div class="level-header">Developing</div>
+                        <div class="level-header">Basic</div>
+                        <div class="level-header">Proficient</div>
+                        <div class="level-header">Distinguished</div>
+                    </div>
+                </div>
+
+                <? for (var i = 0; i < domain.components.length; i++) {
+                    var component = domain.components[i];
+                    var proficiency = data.observation.observationData[component.componentId];
+                ?>
+                    <? if (proficiency) { ?>
+                    <div class="component-section">
+                        <div class="performance-levels-content">
+                            <div class="row-label">
+                                <?= component.title ?>
+                            </div>
+                            <div class="level-content <?= proficiency === 'developing' ? 'selected' : '' ?>">
+                                <?= component.developing ?>
+                            </div>
+                            <div class="level-content <?= proficiency === 'basic' ? 'selected' : '' ?>">
+                                <?= component.basic ?>
+                            </div>
+                            <div class="level-content <?= proficiency === 'proficient' ? 'selected' : '' ?>">
+                                <?= component.proficient ?>
+                            </div>
+                            <div class="level-content <?= proficiency === 'distinguished' ? 'selected' : '' ?>">
+                                <?= component.distinguished ?>
+                            </div>
+                        </div>
+
+                        <? var evidence = data.observation.evidenceLinks[component.componentId]; ?>
+                        <? if (evidence && evidence.length > 0) { ?>
+                        <div class="media-links-container">
+                            <strong>Evidence:</strong>
+                            <ul>
+                            <? for (var j = 0; j < evidence.length; j++) { ?>
+                                <li class="media-link-item">
+                                    <a href="<?= evidence[j].url ?>" target="_blank"><?= evidence[j].name ?></a>
+                                </li>
+                            <? } ?>
+                            </ul>
+                        </div>
+                        <? } ?>
+                    </div>
+                    <? } ?>
+                <? } ?>
+            </div>
+            <? } ?>
+        <? } ?>
+    </div>
+</body>
+</html>

--- a/pdf-rubric.html
+++ b/pdf-rubric.html
@@ -5,7 +5,7 @@
     <title>Observation Report</title>
     <style>
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-family: Arial, Helvetica, sans-serif;
             line-height: 1.6;
             color: #333;
             background-color: #fff;
@@ -96,13 +96,24 @@
         }
     </style>
 </head>
+<%
+function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+%>
 <body>
     <div class="container">
         <div class="header">
-            <h1>Observation Report for <?= data.observation.observedName ?></h1>
-            <p>Role: <?= data.observation.observedRole ?> | Year: <?= data.observation.observedYear || 'N/A' ?></p>
-            <p>Observer: <?= data.observation.observerEmail ?></p>
-            <p>Finalized on: <?= new Date(data.observation.finalizedAt).toLocaleString() ?></p>
+            <h1>Observation Report for <?= escapeHtml(data.observation.observedName) ?></h1>
+            <p>Role: <?= escapeHtml(data.observation.observedRole) ?> | Year: <?= escapeHtml(data.observation.observedYear || 'N/A') ?></p>
+            <p>Observer: <?= escapeHtml(data.observation.observerEmail) ?></p>
+            <p>Finalized on: <?= data.observation.finalizedAt ? new Date(data.observation.finalizedAt).toLocaleString() : 'N/A' ?></p>
         </div>
 
         <? for (var domainIdx = 0; domainIdx < data.rubricData.domains.length; domainIdx++) {
@@ -112,7 +123,7 @@
             <? if (domainHasContent) { ?>
             <div class="domain-section">
                 <div class="domain-header">
-                    <?= domain.name ?>
+                    <?= escapeHtml(domain.name) ?>
                 </div>
 
                 <div class="performance-levels-header">
@@ -133,19 +144,19 @@
                     <div class="component-section">
                         <div class="performance-levels-content">
                             <div class="row-label">
-                                <?= component.title ?>
+                                <?= escapeHtml(component.title) ?>
                             </div>
                             <div class="level-content <?= proficiency === 'developing' ? 'selected' : '' ?>">
-                                <?= component.developing ?>
+                                <?= escapeHtml(component.developing) ?>
                             </div>
                             <div class="level-content <?= proficiency === 'basic' ? 'selected' : '' ?>">
-                                <?= component.basic ?>
+                                <?= escapeHtml(component.basic) ?>
                             </div>
                             <div class="level-content <?= proficiency === 'proficient' ? 'selected' : '' ?>">
-                                <?= component.proficient ?>
+                                <?= escapeHtml(component.proficient) ?>
                             </div>
                             <div class="level-content <?= proficiency === 'distinguished' ? 'selected' : '' ?>">
-                                <?= component.distinguished ?>
+                                <?= escapeHtml(component.distinguished) ?>
                             </div>
                         </div>
 
@@ -156,7 +167,7 @@
                             <ul>
                             <? for (var j = 0; j < evidence.length; j++) { ?>
                                 <li class="media-link-item">
-                                    <a href="<?= evidence[j].url ?>" target="_blank"><?= evidence[j].name ?></a>
+                                    <a href="<?= escapeHtml(evidence[j].url) ?>" target="_blank"><?= escapeHtml(evidence[j].name) ?></a>
                                 </li>
                             <? } ?>
                             </ul>


### PR DESCRIPTION
This change introduces a new PDF export functionality that generates a PDF visually identical to the rubric view.

- A new `pdf-rubric.html` template has been created to render the rubric for PDF export.
- The `exportObservationToPdf` function in `Code.js` has been modified to use this template to generate an HTML representation of the rubric and then convert it to a PDF.
- The new PDF export includes the rubric's visual structure, highlights the selected proficiency, and preserves live links to media uploads.