### PR TITLE
feat: Add finalized observation email notification

### DIFF
--- a/finalized-observation-email.html
+++ b/finalized-observation-email.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+  </head>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 5px;">
+      <h2 style="color: #333;">Observation Finalized</h2>
+      <p>Dear <?= staffName ?>,</p>
+      <p>Your recent observation has been finalized by your peer evaluator. The materials and rubric are now available for your review.</p>
+      <p>Please click the button below to access the observation folder in Google Drive.</p>
+      <table width="100%" cellspacing="0" cellpadding="0">
+        <tr>
+          <td>
+            <table cellspacing="0" cellpadding="0" style="margin: 30px auto;">
+              <tr>
+                <td align="center" style="border-radius: 5px; background-color: #4285F4; padding: 14px 24px;">
+                  <a href="<?= folderUrl ?>" target="_blank" style="color: #ffffff; text-decoration: none; font-weight: bold; font-size: 16px;">View Observation Materials</a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+      <p>If you have any questions, please reach out to your evaluator.</p>
+      <hr style="border: 0; border-top: 1px solid #eee;">
+      <p style="font-size: 12px; color: #888;">This is an automated message from the Danielson Framework System.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This feature adds a professionally stylized email notification to the staff member when their observation is finalized.

The email is sent from the peer evaluator who finalized the observation and contains a button that links to the Google Drive folder for that observation.

Changes include:
- A new HTML template for the email (`finalized-observation-email.html`).
- A new helper function `_getObservationFolder` to get or create the observation's Google Drive folder.
- A new function `_sendFinalizedEmail` to send the email using `GmailApp`.
- An update to `updateObservationStatus` to call the new email function when an observation is finalized.