### PR TITLE
Fix(pdf): Correct scriptlet tags in PDF generation template.

### DIFF
--- a/pdf-rubric.html
+++ b/pdf-rubric.html
@@ -96,7 +96,7 @@
         }
     </style>
 </head>
-<%
+<?
 function escapeHtml(str) {
     if (str == null) return '';
     return String(str)
@@ -106,7 +106,7 @@ function escapeHtml(str) {
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
 }
-%>
+?>
 <body>
     <div class="container">
         <div class="header">


### PR DESCRIPTION
The PDF regeneration feature was failing with a "Malformed HTML content" error.

This was caused by the use of incorrect scriptlet tags (`<% ... %>`) in the `pdf-rubric.html` template. Google Apps Script's `HtmlService` templating engine does not recognize these tags, causing the scriptlet's content to be rendered as literal text and breaking the HTML structure.

This commit corrects the tags to the proper syntax (`<? ... ?>`), ensuring the template is evaluated correctly and valid HTML is generated for the PDF conversion process.