### PR TITLE
Fix(PDF): Use setAttributes for cell borders in PDF export

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -749,7 +749,17 @@ function _addComponentSection(body, component, proficiency, observation) {
                 ...(cell.getAttributes() || {}),
                 [DocumentApp.Attribute.BORDER_WIDTH]: 2,
                 [DocumentApp.Attribute.BORDER_COLOR]: '#3b82f6'
-            });
+            // Safely copy existing attributes to a plain object before merging
+            var attrs = {};
+            var existingAttrs = cell.getAttributes();
+            if (existingAttrs) {
+                Object.keys(existingAttrs).forEach(function(key) {
+                    attrs[key] = existingAttrs[key];
+                });
+            }
+            attrs[DocumentApp.Attribute.BORDER_WIDTH] = 2;
+            attrs[DocumentApp.Attribute.BORDER_COLOR] = '#3b82f6';
+            cell.setAttributes(attrs);
         } else {
             cell.getChild(0).asText().setForegroundColor('#4a5568');
         }


### PR DESCRIPTION
The `save rubric as pdf` option was failing because the `setBorderWidth` and `setBorderColor` methods were being called on a `TableCell` object, but these methods do not exist for `TableCell` in the `DocumentApp` service. This was causing a runtime error during PDF generation.

This commit fixes the issue by replacing the incorrect method calls with the correct approach using `setAttributes`. It now gets the cell's existing attributes, adds the border width and color attributes, and then applies them back to the cell. This correctly styles the cell border without overwriting other attributes and resolves the script failure.