### PR TITLE
Fix: Complete cell attribute merging logic in Code.js

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -745,12 +745,16 @@ function _addComponentSection(body, component, proficiency, observation) {
             // Selected cell styling with blue background
             cell.setBackgroundColor('#dbeafe');
             cell.getChild(0).asText().setForegroundColor('#1e40af').setBold(true);
-            // Safely merge existing attributes with new border attributes
-            cell.setAttributes({
-              ...(cell.getAttributes() || {}),
-              [DocumentApp.Attribute.BORDER_WIDTH]: 2,
-              [DocumentApp.Attribute.BORDER_COLOR]: '#3b82f6',
-            });
+            // Safely copy existing attributes to a plain object before merging
+            const attributes = cell.getAttributes() || {};
+            const newAttributes = { ...attributes };
+
+            // Add/overwrite the new attributes
+            newAttributes[DocumentApp.Attribute.BORDER_WIDTH] = 2;
+            newAttributes[DocumentApp.Attribute.BORDER_COLOR] = '#3b82f6';
+
+            // Apply the merged attributes
+            cell.setAttributes(newAttributes);
         } else {
             cell.getChild(0).asText().setForegroundColor('#4a5568');
         }

--- a/Code.js
+++ b/Code.js
@@ -745,16 +745,12 @@ function _addComponentSection(body, component, proficiency, observation) {
             // Selected cell styling with blue background
             cell.setBackgroundColor('#dbeafe');
             cell.getChild(0).asText().setForegroundColor('#1e40af').setBold(true);
-            // Safely copy existing attributes to a plain object before merging
-            const attributes = cell.getAttributes() || {};
-            const newAttributes = { ...attributes };
-
-            // Add/overwrite the new attributes
-            newAttributes[DocumentApp.Attribute.BORDER_WIDTH] = 2;
-            newAttributes[DocumentApp.Attribute.BORDER_COLOR] = '#3b82f6';
-
-            // Apply the merged attributes
-            cell.setAttributes(newAttributes);
+            // Safely merge existing attributes with new border attributes
+            cell.setAttributes({
+              ...(cell.getAttributes() || {}),
+              [DocumentApp.Attribute.BORDER_WIDTH]: 2,
+              [DocumentApp.Attribute.BORDER_COLOR]: '#3b82f6',
+            });
         } else {
             cell.getChild(0).asText().setForegroundColor('#4a5568');
         }

--- a/Code.js
+++ b/Code.js
@@ -745,7 +745,16 @@ function _addComponentSection(body, component, proficiency, observation) {
             // Selected cell styling with blue background
             cell.setBackgroundColor('#dbeafe');
             cell.getChild(0).asText().setForegroundColor('#1e40af').setBold(true);
-            cell.setBorderWidth(2).setBorderColor('#3b82f6');
+            // Safely copy existing attributes to a plain object before merging
+            const attributes = cell.getAttributes() || {};
+            const newAttributes = { ...attributes };
+
+            // Add/overwrite the new attributes
+            newAttributes[DocumentApp.Attribute.BORDER_WIDTH] = 2;
+            newAttributes[DocumentApp.Attribute.BORDER_COLOR] = '#3b82f6';
+
+            // Apply the merged attributes
+            cell.setAttributes(newAttributes);
         } else {
             cell.getChild(0).asText().setForegroundColor('#4a5568');
         }


### PR DESCRIPTION
This commit completes the logic for merging cell attributes in the `_addComponentSection` function in `Code.js`.

The previous implementation was incomplete and had been replaced with separate calls to `setBorderWidth` and `setBorderColor`. This commit restores the intended merging logic in a safe and concise way.

The new implementation:
- Retrieves the existing cell attributes.
- Safely creates a new object with the existing attributes.
- Adds the new border attributes to the new object.
- Applies the merged attributes back to the cell.

This addresses the issue raised in the pull request comment about the incomplete merging logic.