### PR TITLE
feat: Make filter interface header sticky

### DIFF
--- a/filter-interface.html
+++ b/filter-interface.html
@@ -81,6 +81,9 @@
             color: var(--color-white);
             padding: 40px 30px;
             text-align: center;
+            position: sticky;
+            top: 0;
+            z-index: 101;
         }
 
         .header h1 {
@@ -856,10 +859,14 @@
             }); 
             document.getElementById(viewId).style.display = 'block'; 
             
-            // Show/hide sticky nav based on view
+            const header = document.querySelector('.header');
+
+            // Show/hide sticky nav and header based on view
             if (viewId === 'rubricContainer') {
+                if (header) header.style.display = 'none';
                 // Nav will be shown by handleRubricData
             } else {
+                if (header) header.style.display = 'block';
                 hideStickyNav();
             }
         }

--- a/filter-interface.html
+++ b/filter-interface.html
@@ -863,10 +863,10 @@
 
             // Show/hide sticky nav and header based on view
             if (viewId === 'rubricContainer') {
-                if (header) header.style.display = 'none';
+                if (header) header.classList.add('hidden');
                 // Nav will be shown by handleRubricData
             } else {
-                if (header) header.style.display = 'block';
+                if (header) header.classList.remove('hidden');
                 hideStickyNav();
             }
         }


### PR DESCRIPTION
Makes the main header on the filter interface sticky so that it remains visible at the top of the viewport when scrolling.

The JavaScript logic for view switching has been updated to hide this main header when the rubric view is active, preventing it from overlapping with the rubric's own dedicated sticky navigation bar.