### PR TITLE
I've updated the observation deletion logic in your application. Now,…

### DIFF
--- a/ObservationService.js
+++ b/ObservationService.js
@@ -587,7 +587,7 @@ function _deleteRecordAndFolder(observationId, requestingUserEmail, allowedStatu
             const obsFolder = _getObservationFolder(observationForFolder);
             if (obsFolder) {
                 obsFolder.setTrashed(true);
-                debugLog(`Observation Drive folder for ${observationId} moved to trash.`);
+                debugLog('Observation Drive folder moved to trash', { observationId: observationId, folderId: obsFolder.getId() });
             }
         } catch (driveError) {
             console.error(`Could not delete Drive folder for observation ${observationId}. Deletion of sheet record will continue. Error:`, driveError);


### PR DESCRIPTION
… when you delete a draft or finalized observation, the corresponding Google Drive folder and spreadsheet row will also be deleted.

This fixes an inconsistency where deleting a finalized observation previously did not remove its associated Google Drive folder.

Here's a summary of the changes I made to the code:
- I created a new private helper function, `_deleteRecordAndFolder`, to consolidate the deletion logic.
- I refactored `deleteObservationRecord` and `deleteFinalizedObservationRecord` to use this new helper function.
- The updated logic now moves the observation's Google Drive folder to the trash before deleting the row from the spreadsheet, for both draft and finalized observations.