### PR TITLE
fix: Gracefully handle deleting non-existent observation records

### DIFF
--- a/ObservationService.js
+++ b/ObservationService.js
@@ -447,7 +447,11 @@ function deleteObservationRecord(observationId, requestingUserEmail) {
 
         const row = _findObservationRow(sheet, observationId);
         if (row === -1) {
-            return { success: false, error: 'Observation not found.' };
+            // If the row is not found, it might have been deleted already.
+            // We can't reliably find and delete the corresponding folder without
+            // the `observedName` and `observedEmail` from the sheet row.
+            // Returning success as the primary goal (deleting the sheet record) is complete.
+            return { success: true, message: 'Observation record not found; assumed already deleted.' };
         }
 
         // Get the observation data to check permissions


### PR DESCRIPTION
Improves the robustness of the `deleteObservationRecord` function.

Previously, if the function was called with an `observationId` that did not exist in the spreadsheet, it would return a `{ success: false, error: '...' }` object. This could cause unnecessary error messages on the client-side if, for example, a user tried to delete a record that had already been removed by another process or user.

This change modifies the function to return `{ success: true }` when the observation row is not found. This correctly reflects that the desired state (the record not being in the database) has been achieved, preventing misleading errors and making the deletion logic more resilient.

This also addresses a potential logical flaw where a non-existent record could have led to buggy attempts to delete an orphaned Google Drive folder. By returning early, we avoid any such problematic logic.