### PR TITLE
Fix: Pass scriptEditorSettings to filter interface template

### DIFF
--- a/client/peerevaluator/filter-interface.html
+++ b/client/peerevaluator/filter-interface.html
@@ -1992,7 +1992,7 @@
         }
 
         // === Script Editor Functions ===
-        const SCRIPT_EDITOR_CONSTANTS = <?= JSON.stringify(scriptEditorSettings) ?>;
+        const SCRIPT_EDITOR_CONSTANTS = <?!= JSON.stringify(scriptEditorSettings) ?>;
         let scriptQuill = null;
         let scriptContent = {};
 

--- a/server/UiService.js
+++ b/server/UiService.js
@@ -21,6 +21,7 @@ const UiService = (function() {
       htmlTemplate.availableRoles = AVAILABLE_ROLES;
       htmlTemplate.availableYears = OBSERVATION_YEARS;
       htmlTemplate.requestId = requestId;
+      htmlTemplate.scriptEditorSettings = SCRIPT_EDITOR_SETTINGS;
 
       const htmlOutput = htmlTemplate.evaluate()
         .setTitle(`${userContext.role} - Filter View`)


### PR DESCRIPTION
The `filter-interface.html` template uses the `scriptEditorSettings` variable, but it was not being passed from the server-side `createFilterSelectionInterface` function in `UiService.js`.

This change adds the missing `scriptEditorSettings` to the template data, resolving the `ReferenceError`.