### PR TITLE
Fix script editor data persistence and stale data issues

### DIFF
--- a/client/peerevaluator/filter-interface.html
+++ b/client/peerevaluator/filter-interface.html
@@ -2262,18 +2262,21 @@
                         quillReady: !!scriptQuill
                     });
                     
-                    if (content && scriptQuill) {
-                        if(typeof content === 'object' && content !== null && Object.keys(content).length > 0) {
-                            scriptQuill.setContents(content, 'silent');
-                            scriptContent = content;
-                            console.log('Script content successfully loaded into editor');
-                        } else {
-                            console.log('Script content exists but is empty or invalid format');
-                        }
-                    } else if (!scriptQuill) {
+                    if (!scriptQuill) {
                         console.error('Cannot load script content: Quill editor not initialized');
+                        return;
+                    }
+
+                    // Check if content is a valid, non-empty object
+                    if (content && typeof content === 'object' && Object.keys(content).length > 0) {
+                        scriptQuill.setContents(content, 'silent');
+                        scriptContent = content;
+                        console.log('Script content successfully loaded into editor');
                     } else {
-                        console.log('No existing script content found for this observation');
+                        // This block now handles null, undefined, or empty object content
+                        scriptQuill.setContents([], 'silent'); // Clear the editor
+                        scriptContent = {}; // Reset local content
+                        console.log('No existing script content found or content was invalid; editor cleared.');
                     }
                 })
                 .withFailureHandler(function(error) {

--- a/server/ObservationService.js
+++ b/server/ObservationService.js
@@ -29,7 +29,7 @@ function _getObservationsDb() {
       headers.forEach((header, index) => {
         let value = row[index];
         // Safely parse JSON fields
-        if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes') && typeof value === 'string' && value) {
+        if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes' || header === 'scriptContent' || header === 'componentTags') && typeof value === 'string' && value) {
           try {
             value = JSON.parse(value);
           } catch (e) {
@@ -102,7 +102,7 @@ function _appendObservationToSheet(observation) {
     const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
     const rowData = headers.map(header => {
       let value = observation[header];
-      if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes') && typeof value === 'object') {
+      if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes' || header === 'scriptContent' || header === 'componentTags') && typeof value === 'object') {
         return JSON.stringify(value, null, 2);
       }
       return value;
@@ -827,7 +827,9 @@ function updateObservationInSheet(observation) {
             // Convert objects to JSON strings for storage
             if ((header === 'observationData' || 
                  header === 'evidenceLinks' || 
-                 header === 'observationNotes') && 
+                 header === 'observationNotes' ||
+                 header === 'scriptContent' ||
+                 header === 'componentTags') &&
                 typeof value === 'object') {
                 return JSON.stringify(value, null, 2);
             }

--- a/server/ObservationService.js
+++ b/server/ObservationService.js
@@ -4,6 +4,8 @@
  * This service manages observation records, which are stored as rows in the "Observation_Data" Google Sheet.
  */
 
+const JSON_SERIALIZED_FIELDS = ['observationData', 'evidenceLinks', 'observationNotes', 'scriptContent', 'componentTags'];
+
 
 /**
  * Retrieves the entire observations database from the Google Sheet.
@@ -29,7 +31,7 @@ function _getObservationsDb() {
       headers.forEach((header, index) => {
         let value = row[index];
         // Safely parse JSON fields
-        if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes' || header === 'scriptContent' || header === 'componentTags') && typeof value === 'string' && value) {
+        if (JSON_SERIALIZED_FIELDS.includes(header) && typeof value === 'string' && value) {
           try {
             value = JSON.parse(value);
           } catch (e) {
@@ -102,7 +104,7 @@ function _appendObservationToSheet(observation) {
     const headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
     const rowData = headers.map(header => {
       let value = observation[header];
-      if ((header === 'observationData' || header === 'evidenceLinks' || header === 'observationNotes' || header === 'scriptContent' || header === 'componentTags') && typeof value === 'object') {
+      if (JSON_SERIALIZED_FIELDS.includes(header) && typeof value === 'object') {
         return JSON.stringify(value, null, 2);
       }
       return value;
@@ -825,12 +827,7 @@ function updateObservationInSheet(observation) {
             let value = observation[header];
             
             // Convert objects to JSON strings for storage
-            if ((header === 'observationData' || 
-                 header === 'evidenceLinks' || 
-                 header === 'observationNotes' ||
-                 header === 'scriptContent' ||
-                 header === 'componentTags') &&
-                typeof value === 'object') {
+            if (JSON_SERIALIZED_FIELDS.includes(header) && typeof value === 'object') {
                 return JSON.stringify(value, null, 2);
             }
             

--- a/server/SheetService.js
+++ b/server/SheetService.js
@@ -938,7 +938,8 @@ function setupObservationSheet() {
       "observationId", "observerEmail", "observedEmail", "observedName",
       "observedRole", "observedYear", "status", "createdAt",
       "lastModifiedAt", "finalizedAt", "observationData", "evidenceLinks",
-      "observationName", "observationDate", "pdfUrl", "pdfStatus"
+      "scriptContent", "componentTags", "observationName", "observationDate",
+      "pdfUrl", "pdfStatus"
     ];
 
     // Check if headers are already present


### PR DESCRIPTION
This commit addresses two critical bugs in the Script Editor feature:

1.  **PDF Export Failure**: The script content was not being correctly saved to the `Observation_Data` sheet because it was not being JSON stringified, and the sheet was not being read for this field correctly. This caused the PDF generation service to fail with a "No script content found" error.

2.  **Stale Data Display**: The client-side logic did not clear the script editor when loading an observation with no script content. This caused the script from a previously viewed observation to remain visible, leading to confusion.

Changes:
- Modified `server/ObservationService.js` to correctly handle JSON serialization and deserialization for the `scriptContent` and `componentTags` fields.
- Modified `server/SheetService.js` to ensure the `scriptContent` and `componentTags` columns are always present in the `Observation_Data` sheet.
- Updated `client/peerevaluator/filter-interface.html` to clear the Quill editor when loading an observation that has no script content.