### PR TITLE
Feat: Add view-only access for observed staff

### DIFF
--- a/client/staff/rubric.html
+++ b/client/staff/rubric.html
@@ -984,8 +984,8 @@
         <div class="header">
             <h1><?= data.title ?></h1>
             <p><?= data.subtitle ?></p>
-            <!-- View Mode Toggle (only for users with assigned subdomains) -->
-            <? if (data.userContext && data.userContext.assignedSubdomains && !data.userContext.hasSpecialAccess) { ?>
+            <!-- View Mode Toggle (for users with assigned subdomains or observed staff) -->
+            <? if (data.userContext && data.userContext.assignedSubdomains && (!data.userContext.hasSpecialAccess || data.userContext.isObservedStaff)) { ?>
             <div class="view-toggle-container">
                 <button id="viewToggleBtn" class="view-toggle-btn" onclick="toggleViewMode()" aria-pressed="<?= data.userContext.viewMode === 'assigned' ? 'true' : 'false' ?>">
                     <span id="viewToggleText">

--- a/server/Code.js
+++ b/server/Code.js
@@ -582,8 +582,25 @@ function deleteFinalizedObservation(observationId) {
 function loadFinalizedObservationForViewing(observationId) {
     setupObservationSheet(); // Ensure the sheet is ready
     const result = loadObservationForEditing(observationId);
+
+    // After loading, enhance the context for the observed staff member's view
     if (result.success && result.rubricData && result.rubricData.userContext) {
-        result.rubricData.userContext.isEvaluator = false;
+        const userContext = result.rubricData.userContext;
+        const observation = result.observation;
+
+        // The user is viewing their own finalized observation
+        userContext.isEvaluator = false; // Ensure they cannot edit
+        userContext.isObservedStaff = true; // Flag for the new UI behavior
+
+        // Set the view mode to 'assigned' by default for the staff member
+        userContext.viewMode = VIEW_MODES.ASSIGNED;
+
+        debugLog('Finalized observation loaded for observed staff member', {
+            observationId: observationId,
+            userEmail: userContext.email,
+            isObservedStaff: userContext.isObservedStaff,
+            viewMode: userContext.viewMode
+        });
     }
     return result;
 }


### PR DESCRIPTION
This commit implements a view-only interface for staff members to access their finalized observations and rubric information.

The key changes are:

- In `server/Code.js`, the `loadFinalizedObservationForViewing` function has been updated to add an `isObservedStaff` flag to the user context. This ensures that when a staff member is viewing their own finalized observation, the UI can adapt accordingly. The `isEvaluator` flag is also explicitly set to `false` to prevent any editing capabilities.

- In `client/staff/rubric.html`, the conditional logic for displaying the "Assigned Subdomains" / "Full Rubric" toggle has been modified. The toggle is now shown if the user either does not have special access (i.e., they are a regular staff member viewing their own rubric) or if they are an observed staff member viewing a finalized observation. This ensures that the toggle is available in all required scenarios.

These changes fulfill the requirements by providing observed staff members with view-only access to their finalized observations, the full rubric for their role, and the assigned subdomains, with a toggle to switch between the latter two.