### PR TITLE
Refactor Drive folder logic and fix finalization race condition

### DIFF
--- a/server/PdfService.js
+++ b/server/PdfService.js
@@ -172,18 +172,7 @@ const PdfService = (function() {
 
           // Create folder structure
           try {
-              const rootFolderIterator = DriveApp.getFoldersByName(DRIVE_FOLDER_INFO.ROOT_FOLDER_NAME);
-              let rootFolder = rootFolderIterator.hasNext() ? rootFolderIterator.next() : DriveApp.createFolder(DRIVE_FOLDER_INFO.ROOT_FOLDER_NAME);
-              debugLog('Retrieved/created root folder', { observationId, rootFolderId: rootFolder.getId() });
-
-              const userFolderName = `${observation.observedName} (${observation.observedEmail})`;
-              let userFolderIterator = rootFolder.getFoldersByName(userFolderName);
-              let userFolder = userFolderIterator.hasNext() ? userFolderIterator.next() : rootFolder.createFolder(userFolderName);
-              debugLog('Retrieved/created user folder', { observationId, userFolderId: userFolder.getId() });
-
-              const obsFolderName = `Observation - ${observation.observationId}`;
-              let obsFolderIterator = userFolder.getFoldersByName(obsFolderName);
-              let obsFolder = obsFolderIterator.hasNext() ? obsFolderIterator.next() : userFolder.createFolder(obsFolderName);
+              const obsFolder = getOrCreateObservationFolder(observationId);
               debugLog('Retrieved/created observation folder', { observationId, obsFolderId: obsFolder.getId() });
 
               // Use the already created styled PDF blob


### PR DESCRIPTION
This commit addresses two issues related to Google Drive folder sharing for finalized observations:

1.  **Folder Structure:** The logic for creating observation folders has been corrected to create a nested structure as requested: `[Root Folder] / [Staff Name] / [Observation Folder]`. This keeps the evaluator's Drive organized while allowing for specific observation folders to be shared.

2.  **Empty Observation Folders:** A race condition was causing the observation folder to be shared with the staff member before the PDF files were generated and placed in it. This resulted in the staff member seeing an empty folder. The finalization logic has been reordered to ensure that all files are created *before* the folder is shared and the notification email is sent.

Additionally, the code for creating Google Drive folders has been refactored to remove duplication and improve robustness.