### PR TITLE
feat: Implement Admin Role

### DIFF
--- a/client/peerevaluator/filter-interface.html
+++ b/client/peerevaluator/filter-interface.html
@@ -1488,8 +1488,10 @@
             <div id="quickActionsView">
                 <div class="quick-actions"><h2 class="section-title"><span>🎯</span> Quick Actions</h2>
                     <div class="actions-grid">
-                        <? if (userContext.specialRoleType === 'peer_evaluator' || userContext.specialRoleType === 'full_access') { ?>
+                        <? if (userContext.hasSpecialAccess) { ?>
                         <div class="action-card" onclick="showCustomFilters()"><span class="action-icon">🔍</span><div class="action-title">Find Staff & Start Observation</div><div class="action-desc">Filter by role, year, or specific staff member</div></div>
+                        <? } ?>
+                        <? if (userContext.specialRoleType === 'peer_evaluator' || userContext.specialRoleType === 'full_access') { ?>
                         <div class="action-card" onclick="loadMyOwnView()"><span class="action-icon">📋</span><div class="action-title">My Own Rubric</div><div class="action-desc">View your personal assigned areas</div></div>
                         <? } ?>
                     </div>
@@ -1867,7 +1869,7 @@
             google.script.run
                 .withSuccessHandler(handleRubricData)
                 .withFailureHandler(handleError)
-                .createNewObservationForPeerEvaluator(observedEmail); 
+                .createNewObservationForEvaluator(observedEmail);
         }
         function handleEditObservation(obsId) { 
             console.log('Loading observation for editing:', obsId);

--- a/server/Constants.js
+++ b/server/Constants.js
@@ -28,7 +28,8 @@ const STAFF_COLUMNS = {
   NAME: 0,     // Column A: "Name" [LAST, FIRST]
   EMAIL: 1,    // Column B: "Email" [first.last@orono.k12.mn.us]
   ROLE: 2,     // Column C: "Role" 
-  YEAR: 3      // Column D: "Year"
+  YEAR: 3,      // Column D: "Year"
+  BUILDING: 4 // Column E: "Building"
 };
 
 /**

--- a/server/SheetService.js
+++ b/server/SheetService.js
@@ -148,7 +148,7 @@ function getStaffData() {
     }
     
     // Read all data
-    const range = sheet.getRange(2, 1, lastRow - 1, 4);
+    const range = sheet.getRange(2, 1, lastRow - 1, 5);
     const values = range.getValues();
     
     // Check if data has changed
@@ -179,6 +179,7 @@ function getStaffData() {
         name: sanitizeText(row[STAFF_COLUMNS.NAME]),
         email: sanitizeText(row[STAFF_COLUMNS.EMAIL]),
         role: sanitizeText(row[STAFF_COLUMNS.ROLE]),
+        building: sanitizeText(row[4]),
         // year is set below
         rowNumber: rowNumber
       };

--- a/server/UserService.js
+++ b/server/UserService.js
@@ -396,6 +396,7 @@ function createUserContext(email = null) {
     context.isAuthenticated = true;
     context.role = currentUser.role || 'Teacher';
     context.year = currentUser.year || 1;
+    context.building = currentUser.building || null;
     context.hasStaffRecord = true;
     context.isDefaultUser = false;
     context.permissions.canAccessRubric = true;


### PR DESCRIPTION
This commit introduces the Admin role with specific permissions and UI adjustments.

- Admins can now observe probationary and year 3 staff members within their own building.
- The UI for admins is streamlined to only show options for creating or viewing observations.
- The staff selection dropdown for admins is filtered to display only eligible staff members.
- Admins will now use the full rubric for observations, as per the requirements.