### PR TITLE
Fix: Correct missing parenthesis in folder name generation

### DIFF
--- a/server/Code.js
+++ b/server/Code.js
@@ -1144,7 +1144,7 @@ function updateObservationMetadata(observationId, metadata) {
                 const rootFolderIterator = DriveApp.getFoldersByName(DRIVE_FOLDER_INFO.ROOT_FOLDER_NAME);
                 if (rootFolderIterator.hasNext()) {
                     const rootFolder = rootFolderIterator.next();
-                    const userFolderName = `${observation.observedName} (${observation.observedEmail}`;
+                    const userFolderName = `${observation.observedName} (${observation.observedEmail})`;
                     const userFolderIterator = rootFolder.getFoldersByName(userFolderName);
                     if (userFolderIterator.hasNext()) {
                         const userFolder = userFolderIterator.next();


### PR DESCRIPTION
In the `updateObservationMetadata` function in `server/Code.js`, a missing closing parenthesis in the template string for `userFolderName` was causing the Google Drive folder lookup to fail. This prevented observation folders from being renamed when the observation name was updated.

This commit adds the missing parenthesis to ensure the folder name is generated correctly, allowing the rename operation to succeed as intended.