### PR TITLE
Fix: Optimize userFolder creation in test

### DIFF
--- a/server/Code.js
+++ b/server/Code.js
@@ -2970,8 +2970,9 @@ function test_OrphanedFolderBugFix() {
                 : DriveApp.createFolder('Peer Evaluator Form Data');
             
             const userFolderName = 'Test User 2 (test.user2@example.com)';
-            const userFolder = rootFolder.getFoldersByName(userFolderName).hasNext()
-                ? rootFolder.getFoldersByName(userFolderName).next()
+            const userFolderIterator = rootFolder.getFoldersByName(userFolderName);
+            const userFolder = userFolderIterator.hasNext()
+                ? userFolderIterator.next()
                 : rootFolder.createFolder(userFolderName);
             
             const obsFolder = userFolder.createFolder(FOLDER_NAME_2);


### PR DESCRIPTION
Refactors the `userFolder` creation in the `test_OrphanedFolderBugFix` function to avoid calling `getFoldersByName` twice. This is done by storing the iterator in a variable and reusing it, which reduces the number of Google Drive API calls.

This change mirrors the optimization already applied to `rootFolder`.