### PR TITLE
feat: Implement granular caching for staff data

### DIFF
--- a/server/SheetService.js
+++ b/server/SheetService.js
@@ -237,6 +237,12 @@ function getStaffData() {
     
     // Cache with enhanced system
     setCachedDataEnhanced('staff_data', {}, staffData, CACHE_SETTINGS.SHEET_DATA_TTL);
+
+    // Also cache each user individually for granular access
+    users.forEach(user => {
+      const cacheParams = { email: user.email.toLowerCase().trim() };
+      setCachedDataEnhanced('user', cacheParams, user, CACHE_SETTINGS.USER_DATA_TTL);
+    });
     
     const executionTime = Date.now() - startTime;
     logPerformanceMetrics('getStaffData', executionTime, {


### PR DESCRIPTION
This commit improves the performance of the application by implementing a more granular caching strategy for staff data in `server/SheetService.js`.

Previously, the `getStaffData` function cached the entire staff list as a single entry. This meant that if the cache was invalidated (e.g., by a change to a single user in the "Staff" sheet), the entire list had to be re-fetched from the Google Sheet, which is a slow operation.

This change modifies `getStaffData` to also cache each user's data individually, using a user-specific cache key. The `getUserByEmail` function in `server/UserService.js` already reads from this individual user cache.

This change ensures that when `getStaffData` is called, it primes the cache for all individual users. This makes subsequent calls to `getUserByEmail` much faster, as they are more likely to result in a cache hit, even if the main `'staff_data'` cache has expired.

This is a low-risk, high-impact optimization that improves loading times without altering the application's logic or introducing regressions.