### PR TITLE
Fix: Rubric toggle viewMode string comparison bug

### DIFF
--- a/client/staff/rubric.html
+++ b/client/staff/rubric.html
@@ -1804,7 +1804,7 @@
                 <!-- View Mode Toggle (always available for reference viewing) -->
                 <div class="view-toggle-container">
                     <div class="view-toggle-switch">
-                        <button id="assignedToggle" class="toggle-option active" onclick="setViewMode('assigned')">
+                        <button id="assignedToggle" class="toggle-option" onclick="setViewMode('assigned')">
                             📋 Assigned Areas
                         </button>
                         <button id="fullToggle" class="toggle-option" onclick="setViewMode('full')">
@@ -2481,7 +2481,7 @@
         // The following functions manage the view mode (full/assigned) dynamically on the client-side
         // without a page reload. The preference is saved in sessionStorage for the current session.
         // View Mode Toggle Functions
-        let currentViewMode = <?= JSON.stringify(data.userContext?.viewMode || "full").replace(/</g, '\\u003c') ?>;
+        let currentViewMode = '<?= data.userContext?.viewMode || "full" ?>';
         const userAssignedSubdomains = <?= data.userContext?.assignedSubdomains ? JSON.stringify(data.userContext.assignedSubdomains).replace(/</g, '\\u003c') : 'null' ?>;
 
         function toggleViewMode() {


### PR DESCRIPTION
## Summary
- Fixes issue where regular teachers were seeing full rubric instead of assigned areas on page load
- Toggle was visually showing wrong selection due to string comparison failure

## Root Cause
The `JSON.stringify()` function was adding extra quotes to the `viewMode` value, causing string comparisons like `currentViewMode === 'assigned'` to fail.

## Changes
- **Line 1807**: Remove hardcoded `active` class from assignedToggle button to allow proper dynamic styling
- **Line 2484**: Fix viewMode injection to use direct string instead of `JSON.stringify()` to prevent quote issues

## Test Plan
- [ ] Deploy to test environment
- [ ] Test with regular teacher account (non-probationary, non-special access)
- [ ] Verify "Assigned Areas" toggle shows as active on page load
- [ ] Verify only assigned components are visible by default
- [ ] Test toggle switching works correctly
- [ ] Test with special access user to ensure full rubric still works

## Technical Details
Before: `currentViewMode = "assigned"` (with quotes from JSON.stringify)
After: `currentViewMode = 'assigned'` (clean string)

This allows the condition `currentViewMode === 'assigned'` to evaluate to `true`, triggering `hideUnassignedComponents()` instead of `showAllComponents()`.

🤖 Generated with [Claude Code](https://claude.ai/code)