### PR TITLE
refactor: Optimize and fix audio/video upload workflow

### DIFF
--- a/server/Code.js
+++ b/server/Code.js
@@ -1623,8 +1623,8 @@ function uploadGlobalRecording(observationId, base64Data, filename, recordingTyp
         }
         const blob = Utilities.newBlob(binaryData, mimeType, filename);
 
-        // Create/get observation folder
-        const folder = getOrCreateObservationFolder(observationId);
+        // Create/get observation folder, passing the already-fetched observation object
+        const folder = getOrCreateObservationFolder(observationId, observation);
 
         // Save file with specific permissions
         const file = folder.createFile(blob);

--- a/server/ObservationService.js
+++ b/server/ObservationService.js
@@ -347,14 +347,25 @@ function _saveProficiencySelection(observationId, componentId, proficiency) {
 
 /**
  * Retrieves or creates the specific Google Drive folder for a given observation ID.
+ * This function is optimized to accept an optional observation object to prevent
+ * redundant lookups. If the object is not provided, it will be fetched.
  * @param {string} observationId The observation ID.
+ * @param {Object|null} [observation=null] Optional. The observation object to use, if already fetched.
  * @returns {GoogleAppsScript.Drive.Folder} The Google Drive folder for the observation.
  */
-function getOrCreateObservationFolder(observationId) {
-  const observation = getObservationById(observationId);
+function getOrCreateObservationFolder(observationId, observation = null) {
+  // If the observation object isn't provided, fetch it. This maintains backward compatibility.
   if (!observation) {
+    debugLog('Observation object not provided to getOrCreateObservationFolder, fetching from DB.', { observationId });
+    observation = getObservationById(observationId);
+  }
+
+  if (!observation) {
+    // If it's still null, then the observation truly doesn't exist.
     throw new Error(`Observation not found for ID: ${observationId}`);
   }
+
+  // Now, we can be sure we have the observation object and can pass it to the private helper.
   return _getObservationFolder(observation);
 }
 


### PR DESCRIPTION
This commit addresses a critical bug that caused intermittent failures during the upload of global audio and video recordings in the peer evaluator and administrator observation workflow.

The root cause was identified as a severe inefficiency in the `uploadGlobalRecording` function, which was making a redundant and expensive call to `getObservationById` immediately after having already fetched the same data. This redundant call was a performance bottleneck and, under certain conditions, would trigger a generic but fatal "server error" from the Google Apps Script environment, causing the upload to fail.

The fix involves two key changes:

1.  **Refactor `getOrCreateObservationFolder` in `server/ObservationService.js`**: The function has been modified to accept an optional `observation` object. If this object is provided, the function uses it directly, completely bypassing the need for an internal database lookup. This change is fully backward-compatible, as the function will still fetch the data if the object is not provided.

2.  **Update `uploadGlobalRecording` in `server/Code.js`**: The function has been updated to pass the already-retrieved `observation` object to the newly refactored `getOrCreateObservationFolder` function. This eliminates the redundant database read, significantly improving performance and preventing the server error.

These changes make the recording upload process more robust, efficient, and reliable, directly resolving the issue reported in the execution logs.