### PR TITLE
feat: Implement Audio Recordings Modal

### DIFF
--- a/client/peerevaluator/filter-interface.html
+++ b/client/peerevaluator/filter-interface.html
@@ -1783,6 +1783,204 @@
             font-size: 1.2rem;
         }
 
+        /* Audio Modal Specific Styles */
+        .audio-modal-container {
+            max-width: 800px;
+            max-height: 90vh;
+            overflow-y: auto;
+        }
+
+        .audio-recordings-section,
+        .transcription-tools-section,
+        .transcriptions-section {
+            margin-bottom: 30px;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 8px;
+        }
+
+        .audio-recordings-section h3,
+        .transcription-tools-section h3,
+        .transcriptions-section h3 {
+            margin: 0 0 15px 0;
+            color: #2c3e50;
+            font-size: 18px;
+            font-weight: 600;
+        }
+
+        .recordings-list {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .recording-item {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px;
+            background: white;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+            transition: box-shadow 0.2s;
+        }
+
+        .recording-item:hover {
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .recording-checkbox {
+            width: 20px;
+            height: 20px;
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
+        .recording-name {
+            flex: 1;
+            font-size: 14px;
+            color: #495057;
+            font-weight: 500;
+        }
+
+        .recording-name.editing {
+            display: none;
+        }
+
+        .recording-name-input {
+            flex: 1;
+            padding: 6px 10px;
+            border: 2px solid #4CAF50;
+            border-radius: 4px;
+            font-size: 14px;
+            display: none;
+        }
+
+        .recording-name-input.active {
+            display: block;
+        }
+
+        .recording-actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        .recording-action-btn {
+            padding: 6px 12px;
+            border: none;
+            border-radius: 4px;
+            font-size: 14px;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .recording-action-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        }
+
+        .btn-drive {
+            background: #4285f4;
+            color: white;
+        }
+
+        .btn-drive:hover {
+            background: #3367d6;
+        }
+
+        .btn-edit {
+            background: #ff9800;
+            color: white;
+        }
+
+        .btn-edit:hover {
+            background: #f57c00;
+        }
+
+        .btn-save {
+            background: #4CAF50;
+            color: white;
+        }
+
+        .btn-save:hover {
+            background: #45a049;
+        }
+
+        .btn-cancel {
+            background: #9e9e9e;
+            color: white;
+        }
+
+        .btn-cancel:hover {
+            background: #757575;
+        }
+
+        .btn-delete {
+            background: #f44336;
+            color: white;
+        }
+
+        .btn-delete:hover {
+            background: #d32f2f;
+        }
+
+        .feature-notice {
+            padding: 10px 15px;
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 4px;
+            color: #856404;
+            margin-bottom: 15px;
+            font-size: 14px;
+        }
+
+        .helper-text {
+            font-size: 13px;
+            color: #6c757d;
+            margin-top: 10px;
+            font-style: italic;
+        }
+
+        .empty-state {
+            text-align: center;
+            color: #6c757d;
+            font-style: italic;
+            padding: 30px;
+        }
+
+        .action-btn {
+            padding: 10px 20px;
+            background: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-size: 16px;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .action-btn:not(:disabled):hover {
+            background: #45a049;
+        }
+
+        .loading-indicator {
+            text-align: center;
+            padding: 20px;
+            color: #6c757d;
+        }
+
+        .error-message {
+            padding: 12px;
+            background: #f8d7da;
+            border: 1px solid #f5c6cb;
+            border-radius: 4px;
+            color: #721c24;
+            margin-bottom: 15px;
+        }
+
         /* Mobile Responsiveness */
         @media (max-width: 768px) {
             .welcome-modal-overlay {
@@ -2910,6 +3108,24 @@
             }
         }
 
+        function checkForExistingAudioRecordings() {
+            if (!currentObservationId) return;
+
+            google.script.run
+                .withSuccessHandler(function(result) {
+                    if (result.success && result.recordings && result.recordings.length > 0) {
+                        const viewBtn = document.getElementById('viewAudioBtn');
+                        if (viewBtn) {
+                            viewBtn.style.display = 'inline-block';
+                        }
+                    }
+                })
+                .withFailureHandler(function(error) {
+                    console.warn('Could not check for existing recordings:', error);
+                })
+                .getObservationAudioFiles(currentObservationId);
+        }
+
         function handleRubricData(result) {
             hideLoading();
             console.log('handleRubricData received:', result);
@@ -2959,6 +3175,7 @@
                     observationId: currentObservationId,
                     observedUser: currentObservedUser
                 });
+                checkForExistingAudioRecordings();
             }
             observationViewMode = (rubricData.userContext && rubricData.userContext.viewMode) || 'assigned';
 
@@ -3081,6 +3298,9 @@
                 <div class="global-tools-container">
                     <button class="global-tool-btn" id="recordAudioBtn" onclick="toggleAudioRecording()">
                         🎤 Record Audio
+                    </button>
+                    <button class="global-tool-btn" id="viewAudioBtn" onclick="openAudioModal()" style="display: none;">
+                        📁 View Recordings
                     </button>
                     <div id="audioTimerDisplay" class="timer-display"></div>
                     <button class="global-tool-btn" id="recordVideoBtn" onclick="toggleVideoRecording()">
@@ -4496,8 +4716,275 @@
         }
 
         function addGlobalRecording(fileUrl, filename, type) {
-            // Placeholder for now
             console.log(`Recording saved: ${type} at ${fileUrl} with name ${filename}`);
+
+            // Show the "View Recordings" button after successful audio recording
+            if (type === 'audio') {
+                const viewBtn = document.getElementById('viewAudioBtn');
+                if (viewBtn) {
+                    viewBtn.style.display = 'inline-block';
+                }
+            }
+        }
+
+        // === Audio Recordings Modal Functions ===
+
+        // Track editing state
+        let editingRecordingIndex = null;
+
+        /**
+         * Opens the audio recordings modal and loads the recordings list
+         */
+        function openAudioModal() {
+            const modal = document.getElementById('audioRecordingsModal');
+            if (!modal) {
+                console.error('Audio recordings modal not found');
+                return;
+            }
+
+            modal.style.display = 'flex';
+            loadAudioRecordings();
+        }
+
+        /**
+         * Closes the audio recordings modal
+         */
+        function closeAudioModal() {
+            const modal = document.getElementById('audioRecordingsModal');
+            if (modal) {
+                modal.style.display = 'none';
+            }
+            editingRecordingIndex = null;
+        }
+
+        /**
+         * Closes modal when clicking on backdrop
+         */
+        function closeAudioModalBackdrop(event) {
+            if (event.target.id === 'audioRecordingsModal') {
+                closeAudioModal();
+            }
+        }
+
+        /**
+         * Loads and displays the list of audio recordings
+         */
+        function loadAudioRecordings() {
+            const listContainer = document.getElementById('audioRecordingsList');
+            if (!listContainer) return;
+
+            listContainer.innerHTML = '<div class="loading-indicator">Loading recordings...</div>';
+
+            google.script.run
+                .withSuccessHandler(function(result) {
+                    if (result.success) {
+                        displayAudioRecordings(result.recordings);
+                    } else {
+                        listContainer.innerHTML = `<div class="error-message">Error loading recordings: ${result.error}</div>`;
+                    }
+                })
+                .withFailureHandler(function(error) {
+                    listContainer.innerHTML = `<div class="error-message">Failed to load recordings: ${error.message}</div>`;
+                })
+                .getObservationAudioFiles(currentObservationId);
+        }
+
+        /**
+         * Displays the audio recordings in the modal
+         */
+        function displayAudioRecordings(recordings) {
+            const listContainer = document.getElementById('audioRecordingsList');
+            if (!listContainer) return;
+
+            if (!recordings || recordings.length === 0) {
+                listContainer.innerHTML = '<div class="empty-state">No audio recordings yet. Click "Record Audio" to create one.</div>';
+                return;
+            }
+
+            let html = '';
+            recordings.forEach((recording, index) => {
+                const displayName = recording.filename.replace(/\.(mp3|webm)$/, '');
+                html += `
+                    <div class="recording-item" data-index="${index}">
+                        <input type="checkbox"
+                               class="recording-checkbox"
+                               disabled
+                               title="Transcription feature coming soon">
+
+                        <span class="recording-name" id="recordingName_${index}">
+                            ${escapeHtml(displayName)}
+                        </span>
+
+                        <input type="text"
+                               class="recording-name-input"
+                               id="recordingNameInput_${index}"
+                               value="${escapeHtml(displayName)}">
+
+                        <div class="recording-actions" id="recordingActions_${index}">
+                            <button class="recording-action-btn btn-drive"
+                                    onclick="openInDrive('${recording.url}')"
+                                    title="Open in Google Drive">
+                                📂 Drive
+                            </button>
+                            <button class="recording-action-btn btn-edit"
+                                    onclick="startEditRecording(${index}, '${recording.filename}')"
+                                    title="Rename recording">
+                                ✏️ Edit
+                            </button>
+                            <button class="recording-action-btn btn-delete"
+                                    onclick="deleteRecording(${index}, '${recording.filename}')"
+                                    title="Delete recording">
+                                🗑️ Delete
+                            </button>
+                        </div>
+
+                        <div class="recording-actions" id="recordingEditActions_${index}" style="display: none;">
+                            <button class="recording-action-btn btn-save"
+                                    onclick="saveRecordingName(${index}, '${recording.filename}')">
+                                ✓ Save
+                            </button>
+                            <button class="recording-action-btn btn-cancel"
+                                    onclick="cancelEditRecording(${index})">
+                                ✕ Cancel
+                            </button>
+                        </div>
+                    </div>
+                `;
+            });
+
+            listContainer.innerHTML = html;
+        }
+
+        /**
+         * Opens a recording in Google Drive
+         */
+        function openInDrive(url) {
+            window.open(url, '_blank');
+        }
+
+        /**
+         * Starts editing mode for a recording name
+         */
+        function startEditRecording(index, currentFilename) {
+            // Cancel any other editing
+            if (editingRecordingIndex !== null && editingRecordingIndex !== index) {
+                cancelEditRecording(editingRecordingIndex);
+            }
+
+            editingRecordingIndex = index;
+
+            const nameSpan = document.getElementById(`recordingName_${index}`);
+            const nameInput = document.getElementById(`recordingNameInput_${index}`);
+            const normalActions = document.getElementById(`recordingActions_${index}`);
+            const editActions = document.getElementById(`recordingEditActions_${index}`);
+
+            if (nameSpan) nameSpan.style.display = 'none';
+            if (nameInput) {
+                nameInput.classList.add('active');
+                nameInput.focus();
+                nameInput.select();
+            }
+            if (normalActions) normalActions.style.display = 'none';
+            if (editActions) editActions.style.display = 'flex';
+        }
+
+        /**
+         * Saves the new recording name
+         */
+        function saveRecordingName(index, oldFilename) {
+            const nameInput = document.getElementById(`recordingNameInput_${index}`);
+            if (!nameInput) return;
+
+            const newName = nameInput.value.trim();
+            if (!newName) {
+                showToast('Recording name cannot be empty', false);
+                return;
+            }
+
+            // Show loading state
+            const item = document.querySelector(`[data-index="${index}"]`);
+            if (item) {
+                item.style.opacity = '0.5';
+                item.style.pointerEvents = 'none';
+            }
+
+            google.script.run
+                .withSuccessHandler(function(result) {
+                    if (result.success) {
+                        showToast('Recording renamed successfully', true);
+                        cancelEditRecording(index);
+                        loadAudioRecordings(); // Refresh the list
+                    } else {
+                        showToast('Error renaming recording: ' + result.error, false);
+                        if (item) {
+                            item.style.opacity = '1';
+                            item.style.pointerEvents = 'auto';
+                        }
+                    }
+                })
+                .withFailureHandler(function(error) {
+                    showToast('Failed to rename recording: ' + error.message, false);
+                    if (item) {
+                        item.style.opacity = '1';
+                        item.style.pointerEvents = 'auto';
+                    }
+                })
+                .renameObservationAudioFile(currentObservationId, oldFilename, newName);
+        }
+
+        /**
+         * Cancels editing mode
+         */
+        function cancelEditRecording(index) {
+            editingRecordingIndex = null;
+
+            const nameSpan = document.getElementById(`recordingName_${index}`);
+            const nameInput = document.getElementById(`recordingNameInput_${index}`);
+            const normalActions = document.getElementById(`recordingActions_${index}`);
+            const editActions = document.getElementById(`recordingEditActions_${index}`);
+
+            if (nameSpan) nameSpan.style.display = 'block';
+            if (nameInput) nameInput.classList.remove('active');
+            if (normalActions) normalActions.style.display = 'flex';
+            if (editActions) editActions.style.display = 'none';
+        }
+
+        /**
+         * Deletes a recording after confirmation
+         */
+        function deleteRecording(index, filename) {
+            if (!confirm(`Are you sure you want to delete this recording?\n\n${filename}\n\nThis action cannot be undone.`)) {
+                return;
+            }
+
+            // Show loading state
+            const item = document.querySelector(`[data-index="${index}"]`);
+            if (item) {
+                item.style.opacity = '0.5';
+                item.style.pointerEvents = 'none';
+            }
+
+            google.script.run
+                .withSuccessHandler(function(result) {
+                    if (result.success) {
+                        showToast('Recording deleted successfully', true);
+                        loadAudioRecordings(); // Refresh the list
+                    } else {
+                        showToast('Error deleting recording: ' + result.error, false);
+                        if (item) {
+                            item.style.opacity = '1';
+                            item.style.pointerEvents = 'auto';
+                        }
+                    }
+                })
+                .withFailureHandler(function(error) {
+                    showToast('Failed to delete recording: ' + error.message, false);
+                    if (item) {
+                        item.style.opacity = '1';
+                        item.style.pointerEvents = 'auto';
+                    }
+                })
+                .deleteObservationAudioFile(currentObservationId, filename);
         }
 
         // === Observation State Management Functions ===
@@ -6637,6 +7124,43 @@
             
             <div class="script-editor-content">
                 <div id="scriptEditor"></div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Audio Recordings Modal -->
+    <div id="audioRecordingsModal" class="modal-overlay" style="display: none;" onclick="closeAudioModalBackdrop(event)">
+        <div class="modal-container audio-modal-container" onclick="event.stopPropagation()">
+            <div class="modal-header">
+                <h2>🎤 Audio Recordings</h2>
+                <button class="modal-close" onclick="closeAudioModal()">✕</button>
+            </div>
+            <div class="modal-content">
+                <!-- Recording List Section -->
+                <div class="audio-recordings-section">
+                    <h3>Recorded Audio Files</h3>
+                    <div id="audioRecordingsList" class="recordings-list">
+                        <!-- Dynamically populated -->
+                    </div>
+                </div>
+
+                <!-- Transcription Tools Section (Disabled Placeholders) -->
+                <div class="transcription-tools-section">
+                    <h3>Transcription Tools</h3>
+                    <p class="feature-notice">🚧 Transcription features coming soon</p>
+                    <button class="action-btn" disabled style="opacity: 0.5; cursor: not-allowed;">
+                        🤖 Get Transcription
+                    </button>
+                    <p class="helper-text">Select audio files above to transcribe (feature in development)</p>
+                </div>
+
+                <!-- Available Transcriptions Section (Placeholder) -->
+                <div class="transcriptions-section">
+                    <h3>Available Transcriptions</h3>
+                    <div id="transcriptionsList" class="transcriptions-list">
+                        <p class="empty-state">No transcriptions available yet</p>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit introduces a new Audio Recordings Modal, allowing users to manage audio files associated with an observation.

The new functionality includes:
- A "View Recordings" button on the global tools bar that appears when audio files are present for the current observation.
- A modal interface to list, rename, and delete existing audio recordings.
- Client-side JavaScript to handle all modal interactions, including API calls to the backend.
- Server-side Google Apps Script functions (`Code.gs`) to:
  - `getObservationAudioFiles`: Retrieve audio file metadata.
  - `renameObservationAudioFile`: Rename files in Google Drive and update spreadsheet records.
  - `deleteObservationAudioFile`: Trash files in Google Drive and update spreadsheet records.
- Placeholder UI for future transcription features.