### PR TITLE
feat: Optimize spreadsheet access with caching

### DIFF
--- a/server/SheetService.js
+++ b/server/SheetService.js
@@ -3,6 +3,8 @@
  * Data access layer for the Danielson Framework Multi-Role System
  */
 
+let _spreadsheet;
+
 /**
  * Gets the Sheet ID from Script Properties
  * @return {string} The spreadsheet ID
@@ -45,16 +47,19 @@ function getSheetByName(spreadsheet, sheetName) {
  * @throws {Error} If spreadsheet cannot be opened
  */
 function openSpreadsheet() {
+  if (_spreadsheet) {
+    return _spreadsheet;
+  }
   try {
     const sheetId = getSheetId();
-    const spreadsheet = SpreadsheetApp.openById(sheetId);
+    _spreadsheet = SpreadsheetApp.openById(sheetId);
     
     debugLog('Spreadsheet opened successfully', {
-      name: spreadsheet.getName(),
-      sheetCount: spreadsheet.getSheets().length
+      name: _spreadsheet.getName(),
+      sheetCount: _spreadsheet.getSheets().length
     });
     
-    return spreadsheet;
+    return _spreadsheet;
   } catch (error) {
     throw new Error(`Failed to open spreadsheet: ${error.message}`);
   }


### PR DESCRIPTION
This commit introduces a performance optimization to `SheetService.js` by caching the spreadsheet object.

Previously, the `openSpreadsheet()` function would call `SpreadsheetApp.openById()` every time it was invoked. This resulted in multiple, redundant API calls within a single server execution, which is a known performance bottleneck in Google Apps Script.

This change introduces a module-level `_spreadsheet` variable to store the spreadsheet object after it's opened for the first time. Subsequent calls to `openSpreadsheet()` within the same execution will now return the cached object, significantly reducing the number of slow API calls and improving the application's overall response time.