### PR TITLE
Fix(CSS): Enable Observation Questions button in read-only view

### DIFF
--- a/client/staff/rubric.html
+++ b/client/staff/rubric.html
@@ -1067,7 +1067,7 @@
         .read-only .look-for-item input,
         .read-only .media-upload-button,
         .read-only .filter-select,
-        .read-only .filter-btn:not(#workProductQuestionsBtn) {
+        .read-only .filter-btn:not(#workProductQuestionsBtn):not(#standardObservationQuestionsBtn) {
             pointer-events: none;
             cursor: not-allowed;
             opacity: 0.7;


### PR DESCRIPTION
The 'Observation Questions' button was unintentionally being disabled on the main rubric page due to an overly broad CSS rule for the `.read-only` mode.

The CSS selector `.read-only .filter-btn:not(#workProductQuestionsBtn)` was disabling all filter buttons except for the work product button.

This change updates the selector to also exclude the `#standardObservationQuestionsBtn`, ensuring it remains interactive and accessible to users as intended.